### PR TITLE
each send_packet() needs a unique count

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -129,6 +129,7 @@ class device:
     self.key = payload[0x04:0x14]
 
   def send_packet(self, command, payload):
+    self.count = (self.count + 1) & 0xffff
     packet = bytearray(0x38)
     packet[0x00] = 0x5a
     packet[0x01] = 0xa5


### PR DESCRIPTION
If one packet is sent with the `count` defined, that can not then be used for a subsequent command. To counter this generate the `count` on each `send_packet()` call.

I am not a Python guy so you may want to clean this up, not sure I have taken the right approach.

@kelvl 

Fixes #12