### PR TITLE
Python 3 compatibility

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -62,7 +62,7 @@ def discover(timeout=None):
 
   devices = []
 
-  timezone = time.timezone/-3600
+  timezone = int(time.timezone/-3600)
   packet = bytearray(0x30)
 
   year = datetime.now().year
@@ -155,20 +155,20 @@ class device:
     payload[0x12] = 0x31
     payload[0x1e] = 0x01
     payload[0x2d] = 0x01
-    payload[0x30] = 'T'
-    payload[0x31] = 'e'
-    payload[0x32] = 's'
-    payload[0x33] = 't'
-    payload[0x34] = ' '
-    payload[0x35] = ' '
-    payload[0x36] = '1'
+    payload[0x30] = ord('T')
+    payload[0x31] = ord('e')
+    payload[0x32] = ord('s')
+    payload[0x33] = ord('t')
+    payload[0x34] = ord(' ')
+    payload[0x35] = ord(' ')
+    payload[0x36] = ord('1')
 
     response = self.send_packet(0x65, payload)
 
     enc_payload = response[0x38:]
 
-    aes = AES.new(str(self.key), AES.MODE_CBC, str(self.iv))
-    payload = aes.decrypt(str(enc_payload))
+    aes = AES.new(bytes(self.key), AES.MODE_CBC, bytes(self.iv))
+    payload = aes.decrypt(bytes(enc_payload))
 
     self.id = payload[0x00:0x04]
     self.key = payload[0x04:0x14]
@@ -205,8 +205,8 @@ class device:
       checksum += payload[i]
       checksum = checksum & 0xffff
 
-    aes = AES.new(str(self.key), AES.MODE_CBC, str(self.iv))
-    payload = aes.encrypt(str(payload))
+    aes = AES.new(bytes(self.key), AES.MODE_CBC, bytes(self.iv))
+    payload = aes.encrypt(bytes(payload))
 
     packet[0x34] = checksum & 0xff
     packet[0x35] = checksum >> 8
@@ -223,7 +223,7 @@ class device:
 
     self.cs.sendto(packet, self.host)
     response = self.cs.recvfrom(1024)
-    return response[0]
+    return bytes(response[0])
 
 
 class sp1(device):
@@ -252,11 +252,11 @@ class sp2(device):
     packet = bytearray(16)
     packet[0] = 1
     response = self.send_packet(0x6a, packet)
-    err = ord(response[0x22]) | (ord(response[0x23]) << 8)
+    err = response[0x22] | (response[0x23] << 8)
     if err == 0:
-      aes = AES.new(str(self.key), AES.MODE_CBC, str(self.iv))
-      payload = aes.decrypt(str(response[0x38:]))
-      return bool(ord(payload[0x4]))
+      aes = AES.new(bytes(self.key), AES.MODE_CBC, bytes(self.iv))
+      payload = aes.decrypt(bytes(response[0x38:]))
+      return bool(payload[0x4])
 
 class a1(device):
   def __init__ (self, host, mac):
@@ -266,14 +266,14 @@ class a1(device):
     packet = bytearray(16)
     packet[0] = 1
     response = self.send_packet(0x6a, packet)
-    err = ord(response[0x22]) | (ord(response[0x23]) << 8)
+    err = response[0x22] | (response[0x23] << 8)
     if err == 0:
       data = {}
-      aes = AES.new(str(self.key), AES.MODE_CBC, str(self.iv))
-      payload = aes.decrypt(str(response[0x38:]))
-      data['temperature'] = (ord(payload[0x4]) * 10 + ord(payload[0x5])) / 10.0
-      data['humidity'] = (ord(payload[0x6]) * 10 + ord(payload[0x7])) / 10.0
-      light = ord(payload[0x8])
+      aes = AES.new(bytes(self.key), AES.MODE_CBC, bytes(self.iv))
+      payload = aes.decrypt(bytes(response[0x38:]))
+      data['temperature'] = (payload[0x4] * 10 + payload[0x5]) / 10.0
+      data['humidity'] = (payload[0x6] * 10 + payload[0x7]) / 10.0
+      light = payload[0x8]
       if light == 0:
         data['light'] = 'dark'
       elif light == 1:
@@ -284,7 +284,7 @@ class a1(device):
         data['light'] = 'bright'
       else:
         data['light'] = 'unknown'
-      air_quality = ord(payload[0x0a])
+      air_quality = payload[0x0a]
       if air_quality == 0:
         data['air_quality'] = 'excellent'
       elif air_quality == 1:
@@ -295,7 +295,7 @@ class a1(device):
         data['air_quality'] = 'bad'
       else:
         data['air_quality'] = 'unknown'
-      noise = ord(payload[0xc])
+      noise = payload[0xc]
       if noise == 0:
         data['noise'] = 'quiet'
       elif noise == 1:
@@ -315,10 +315,10 @@ class rm(device):
     packet = bytearray(16)
     packet[0] = 4
     response = self.send_packet(0x6a, packet)
-    err = ord(response[0x22]) | (ord(response[0x23]) << 8)
+    err = response[0x22] | (response[0x23] << 8)
     if err == 0:
-      aes = AES.new(str(self.key), AES.MODE_CBC, str(self.iv))
-      payload = aes.decrypt(str(response[0x38:]))
+      aes = AES.new(bytes(self.key), AES.MODE_CBC, bytes(self.iv))
+      payload = aes.decrypt(bytes(response[0x38:]))
       return payload[0x04:]
 
   def send_data(self, data):
@@ -335,11 +335,11 @@ class rm(device):
     packet = bytearray(16)
     packet[0] = 1
     response = self.send_packet(0x6a, packet)
-    err = ord(response[0x22]) | (ord(response[0x23]) << 8)
+    err = response[0x22] | (response[0x23] << 8)
     if err == 0:
-      aes = AES.new(str(self.key), AES.MODE_CBC, str(self.iv))
-      payload = aes.decrypt(str(response[0x38:]))
-      temp = (ord(payload[0x4]) * 10 + ord(payload[0x5])) / 10.0
+      aes = AES.new(bytes(self.key), AES.MODE_CBC, bytes(self.iv))
+      payload = aes.decrypt(bytes(response[0x38:]))
+      temp = (payload[0x4] * 10 + payload[0x5]) / 10.0
       return temp
 
 # For legay compatibility - don't use this


### PR DESCRIPTION
Some small fixes to make the library Python 3 compatible as well - mainly replacing `str` with `bytes` and fixing some oddities about `bytearray` on Python 3.

I've tested it on Python 2 and 3 with my SP2 - I haven't changed any logic so it should still work on RM devices as well.