### PR TITLE
Add Crypto as package dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,4 +28,7 @@ setup(
     ],
     include_package_data=True,
     zip_safe=False,
+    install_requires=[
+        'Crypto',
+    ],
 )


### PR DESCRIPTION
This will resolve Crypto as dependency as installing broadlink from pip.

Signed-off-by: Roi Dayan <roi.dayan@gmail.com>