### PR TITLE
validate the authorization

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -179,8 +179,16 @@ class device:
     aes = AES.new(bytes(self.key), AES.MODE_CBC, bytes(self.iv))
     payload = aes.decrypt(bytes(enc_payload))
 
+    if not payload:
+     return False
+
+    key = payload[0x04:0x14]
+    if len(key) % 16 != 0:
+     return False
+
     self.id = payload[0x00:0x04]
-    self.key = payload[0x04:0x14]
+    self.key = key
+    return True
 
   def get_type(self):
     return self.type


### PR DESCRIPTION
For some strange reason the changes in https://github.com/mjg59/python-broadlink/pull/43 makes the a1 sensor unreliable, so this seams to be a more robust solution.