### PR TITLE
Switch from pycrypto to pycryptodome.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pycrypto==2.6.1
+pycryptodome==3.4.4

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     url='http://github.com/mjg59/python-broadlink',
     packages=find_packages(),
     scripts=[],
-    install_requires=['pycrypto==2.6.1'],
+    install_requires=['pycryptodome==3.4.4'],
     description='Python API for controlling Broadlink IR controllers',
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
Installing pycrypto on Windows is a pain - it requires Visual Studio for compilation, or looking for binary distributions by 3rd parties, which aren't always available for the latest Python versions.

Furthermore, the whole project is abandoned, and it's recommended to use pycryptodome instead. It's a drop-in replacement for pycrypto - no need to change the source code at all.