### PR TITLE
bug fix in timeout

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -250,9 +250,8 @@ class device:
           response = self.cs.recvfrom(1024)
           break
         except socket.timeout:
-          if (time.time() - starttime) < self.timeout:
-            pass
-          raise
+          if (time.time() - starttime) > self.timeout:
+            raise
     return bytearray(response[0])
 
 


### PR DESCRIPTION
> It appears that the retry logic isn't working as it should, and an exception is getting thrown after 1 second regardless of the timeout setting. 

Solves this bug: https://github.com/mjg59/python-broadlink/issues/45#issuecomment-272631782