### PR TITLE
Python3.5 syntax changes

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 try:
     from Crypto.Cipher import AES
-except ImportError, e:
+except ImportError as e:
     import pyaes
 
 import time

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import warnings
 try:
     import pyaes
     dynamic_requires = ["pyaes==1.6.0"]
-except ImportError, e:
+except ImportError as e:
     dynamic_requires = ['pycrypto==2.6.1']
 
 version = 0.3


### PR DESCRIPTION
Hello,

Came across a `SyntaxError` when running`python setup.py install` with Python3.5.

Not sure of the contributor guidelines but submitting this PR anyway as see there is a previous commit for Python 3 compatibility  a5d05c95b35a2dff3832dd3eda6ed587a6a4c5d4.

Let me know what you think.

Cheers