### PR TITLE
Pad the payload for AES encryption (16)

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -245,6 +245,11 @@ class device:
     packet[0x32] = self.id[2]
     packet[0x33] = self.id[3]
 
+    # pad the payload for AES encryption
+    if len(payload)>0:
+      numpad=(len(payload)//16+1)*16
+      payload=payload.ljust(numpad,"\x00")
+
     checksum = 0xbeaf
     for i in range(len(payload)):
       checksum += payload[i]


### PR DESCRIPTION
Pad the payload for AES encryption for 16 bytes.

There's no need to do any fixCodeLength mumbo jumbo like here:
https://gist.github.com/narongdejsrn/1f199ce1115a36dbb82878f6ba0cd75b
