### PR TITLE
Restore Python 3 support

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -159,11 +159,11 @@ class device:
 
   def encrypt_pyaes(self, payload):
     aes = pyaes.AESModeOfOperationCBC(self.key, iv = bytes(self.iv))
-    return "".join([aes.encrypt(bytes(payload[i:i+16])) for i in range(0, len(payload), 16)])
+    return b"".join([aes.encrypt(bytes(payload[i:i+16])) for i in range(0, len(payload), 16)])
 
   def decrypt_pyaes(self, payload):
     aes = pyaes.AESModeOfOperationCBC(self.key, iv = bytes(self.iv))
-    return "".join([aes.decrypt(bytes(payload[i:i+16])) for i in range(0, len(payload), 16)])
+    return b"".join([aes.decrypt(bytes(payload[i:i+16])) for i in range(0, len(payload), 16)])
 
   def encrypt_pycrypto(self, payload):
     aes = AES.new(bytes(self.key), AES.MODE_CBC, bytes(self.iv))
@@ -248,7 +248,7 @@ class device:
     # pad the payload for AES encryption
     if len(payload)>0:
       numpad=(len(payload)//16+1)*16
-      payload=payload.ljust(numpad,"\x00")
+      payload=payload.ljust(numpad, b"\x00")
 
     checksum = 0xbeaf
     for i in range(len(payload)):


### PR DESCRIPTION
Use explicit byte literals.

AES encryption padding broken with commit f7e30344c5748e37924c8a4f28522c2bc99a52ee under Python 3.
Python 3 support when using pyaes (instead of Crypto.Cipher.AES) now works.

Tested with Python 2.7.13 and Python 3.6.1.