### PR TITLE
New options for broadlink_cli: --convert and --durations.

### DIFF
--- a/cli/broadlink_cli
+++ b/cli/broadlink_cli
@@ -5,8 +5,62 @@ import sys
 import argparse
 import time
 
+TICK = 32.84
+IR_TOKEN = 0x26
+
+
 def auto_int(x):
     return int(x, 0)
+
+
+def to_microseconds(bytes):
+    result = []
+    #  print bytes[0] # 0x26 = 38for IR
+    length = bytes[2] + 256 * bytes[3]  # presently ignored
+    index = 4
+    while index < len(bytes):
+        chunk = bytes[index]
+        index += 1
+        if chunk == 0:
+            chunk = bytes[index]
+            chunk = 256 * chunk + bytes[index + 1]
+            index += 2
+        result.append(int(round(chunk*TICK)))
+        if chunk == 0x0d05:
+            break
+    return result
+
+
+def durations_to_broadlink(durations):
+    result = bytearray()
+    result.append(IR_TOKEN)
+    result.append(0)
+    result.append(len(durations) % 256)
+    result.append(len(durations) / 256)
+    for dur in durations:
+        num = int(round(dur/TICK))
+        if num > 255:
+            result.append(0)
+            result.append(num / 256)
+        result.append(num % 256)
+    return result
+
+
+def format_durations(data):
+    result = ''
+    for i in range(0, len(data)):
+        if len(result) > 0:
+            result += ' '
+        result += ('+' if i % 2 == 0 else '-') + str(data[i])
+    return result
+
+
+def parse_durations(str):
+    result = []
+    for s in str.split():
+        result.append(abs(int(s)))
+    return result
+
 
 parser = argparse.ArgumentParser(fromfile_prefix_chars='@');
 parser.add_argument("--device", help="device definition as 'type host mac'")
@@ -14,10 +68,13 @@ parser.add_argument("--type", type=auto_int, default=0x2712, help="type of devic
 parser.add_argument("--host", help="host address")
 parser.add_argument("--mac", help="mac address (hex reverse), as used by python-broadlink library")
 parser.add_argument("--temperature",action="store_true", help="request temperature from device")
-parser.add_argument("--send", help="send command")
-parser.add_argument("--sensors",action="store_true", help="check all sensors")
-parser.add_argument("--learn",action="store_true", help="learn command")
+parser.add_argument("--send", action="store_true", help="send command")
+parser.add_argument("--sensors", action="store_true", help="check all sensors")
+parser.add_argument("--learn", action="store_true", help="learn command")
 parser.add_argument("--learnfile", help="learn command and save to specified file")
+parser.add_argument("--durations", action="store_true", help="use durations in micro seconds instead of the Broadlink format")
+parser.add_argument("--convert", action="store_true", help="convert input data to durations")
+parser.add_argument("data", nargs='*', help="Data to send or convert")
 args = parser.parse_args()
 
 if args.device:
@@ -25,14 +82,19 @@ if args.device:
     type = int(values[0],0)
     host = values[1]
     mac = bytearray.fromhex(values[2])
-else:
+elif args.mac:
     type = args.type
     host = args.host
     mac = bytearray.fromhex(args.mac)
 
+if args.host:
+    dev = broadlink.gendevice(type, (host, 80), mac)
+    dev.auth()
 
-dev = broadlink.gendevice(type, (host, 80), mac)
-dev.auth()
+if args.convert:
+    data = bytearray.fromhex(''.join(args.data))
+    durations = to_microseconds(data)
+    print format_durations(durations)
 if args.temperature:
     print dev.check_temperature()
 if args.sensors:
@@ -44,7 +106,8 @@ if args.sensors:
     for key in data:
         print "{} {}".format(key, data[key])
 if args.send:
-    data = bytearray.fromhex(args.send)
+    data = durations_to_broadlink(parse_durations(' '.join(args.data))) \
+        if args.durations else bytearray.fromhex(''.join(args.data))
     dev.send_data(data)
 if args.learn or args.learnfile:
     dev.enter_learning()
@@ -56,7 +119,9 @@ if args.learn or args.learnfile:
         timeout -= 2
         data = dev.check_data()
     if data:
-        learned = ''.join(format(x, '02x') for x in bytearray(data))
+        learned = format_durations(to_microseconds(bytearray(data))) \
+            if args.durations \
+            else ''.join(format(x, '02x') for x in bytearray(data))
         if args.learn:
             print learned    
         if args.learnfile:


### PR DESCRIPTION
This PR implements two new options for broadlink_cli: `--durations` and `--convert`. 

With the `--durations` option, the argument to send instead are durations in microseconds (possible signs accepted and ignored). For example

    ./broadlink_cli --host ... ... --durations --send +9024 -4512 +564 -564 +564 -564 +564 -564 +564 -564 +564 -564 +564 -564 +564 -564 +564 -1692 +564 -1692 +564 -1692 +564 -1692 +564 -1692 +564 -1692 +564 -1692 +564 -1692 +564 -1692 +564 -1692 +564 -1692 +564 -1692 +564 -1692 +564 -1692 +564 -564 +564 -564 +564 -564 +564 -564 +564 -564 +564 -564 +564 -564 +564 -564 +564 -1692 +564 -1692 +564 -1692 +564 -38628 +9024 -2256 +564 -96156

sends a certain NEC1 signal. (Of course, this has to be computed (or read, "learned") by another program. Presently only IR support (no RF).

Using `--learn` (and `--learnfile`) the results is given as durations in micro seconds, with signs.

The `--convert` option converts Broadlink data to durations, without sending.