### PR TITLE
[Critical] Fixes invalid byte string (b) for padding (#97, #107)

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -248,7 +248,7 @@ class device:
     # pad the payload for AES encryption
     if len(payload)>0:
       numpad=(len(payload)//16+1)*16
-      payload=payload.ljust(numpad,"\x00")
+      payload=payload.ljust(numpad,b"\x00")
 
     checksum = 0xbeaf
     for i in range(len(payload)):

--- a/setup.py
+++ b/setup.py
@@ -12,11 +12,11 @@ try:
 except ImportError as e:
     dynamic_requires = ['pycrypto==2.6.1']
 
-version = 0.3
+version = 0.5
 
 setup(
     name='broadlink',
-    version=0.4,
+    version=0.5,
     author='Matthew Garrett',
     author_email='mjg59@srcf.ucam.org',
     url='http://github.com/mjg59/python-broadlink',


### PR DESCRIPTION
Different users experienced error #97 , #107 in the code of padding 16-bytes for AES encryption.

```python
Python 3.5.1 (v3.5.1:37a07cee5969, Dec  6 2015, 01:38:48) [MSC v.1900 32 bit (Intel)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import broadlink
>>> devs = broadlink.discover(timeout=5)
>>> devs[0].auth()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\Anthony\Desktop\pb-test\python-broadlink\broadlink\__init__.py", line 203, in auth
    response = self.send_packet(0x65, payload)
  File "C:\Users\Anthony\Desktop\pb-test\python-broadlink\broadlink\__init__.py", line 251, in send_packet
    payload=payload.ljust(numpad,"\x00")
TypeError: must be a byte string of length 1, not str
>>>
```

This modifies:
- Adds ```b``` to ```"\x00"``` to convert "byte string" to byte array
- Changes version to 0.5 (I don't know am I right?)