### PR TITLE
Cli venv support

### DIFF
--- a/cli/broadlink_cli
+++ b/cli/broadlink_cli
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import broadlink
 import sys

--- a/cli/broadlink_discovery
+++ b/cli/broadlink_discovery
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import broadlink
 import time


### PR DESCRIPTION
Quick patch to make the cli scripts work with virtualenvs.
Pretty straight-forward: change the `#!` directive to `/usr/bin/env python` which is equivalent to `/usr/bin/python` to most users, but will use the right python binary when using virtual envs.