### PR TITLE
Checking device arg too for defining dev instance

### DIFF
--- a/cli/broadlink_cli
+++ b/cli/broadlink_cli
@@ -87,7 +87,7 @@ elif args.mac:
     host = args.host
     mac = bytearray.fromhex(args.mac)
 
-if args.host:
+if args.host or args.device:
     dev = broadlink.gendevice(type, (host, 80), mac)
     dev.auth()
 
@@ -123,11 +123,10 @@ if args.learn or args.learnfile:
             if args.durations \
             else ''.join(format(x, '02x') for x in bytearray(data))
         if args.learn:
-            print learned    
+            print learned
         if args.learnfile:
             print "Saving to {}".format(args.learnfile)
             with open(args.learnfile, "w") as text_file:
                 text_file.write(learned)
     else:
         print "No data received..."
-            


### PR DESCRIPTION
Hello!

Recent changes failed with cli, if we don't declare dev instance with using `--device` argument parameters.

```
Traceback (most recent call last):
  File "broadlink_cli", line 113, in <module>
    dev.enter_learning()
NameError: name 'dev' is not defined
```

I add simple check for device arg too, as wee have two main type of declaring and working with devices.