### PR TITLE
Added support for python3 for get_energy

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -400,6 +400,16 @@ class sp2(device):
       energy = int(hex(ord(payload[7]) * 256 + ord(payload[6]))[2:]) + int(hex(ord(payload[5]))[2:])/100.0
       return energy
 
+  def get_energy_raw_p3(self):
+    packet = bytearray([8, 0, 254, 1, 5, 1, 0, 0, 0, 45])
+    response = self.send_packet(0x6a, packet)
+    err = response[0x22] | (response[0x23] << 8)
+    if err == 0:
+      data = {}
+      payload = self.decrypt(bytes(response[0x38:]))
+      data['energy'] = int(hex(payload[7] * 256 + payload[6])[2:]) + int(hex(payload[5])[2:])/100.0
+      return data
+
 
 class a1(device):
   def __init__ (self, host, mac):
@@ -582,7 +592,6 @@ class S1C(device):
         }
         return result
 
-
 class dooya(device):
   def __init__ (self, host, mac):
     device.__init__(self, host, mac)
@@ -628,6 +637,8 @@ class dooya(device):
         time.sleep(0.2)
         current = self.get_percentage()
     self.stop()
+
+
 
 # Setup a new Broadlink device via AP Mode. Review the README to see how to enter AP Mode.
 # Only tested with Broadlink RM3 Mini (Blackbean)


### PR DESCRIPTION
And also formatted get_energy same as check_sensors_raw

Added it as a new def with name get_energy_raw_p3

This makes this script usable by home assistant as python3 support is required. 