### PR TITLE
Default support for python3 in get_energy() for SP2

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -397,7 +397,10 @@ class sp2(device):
     err = response[0x22] | (response[0x23] << 8)
     if err == 0:
       payload = self.decrypt(bytes(response[0x38:]))
-      energy = int(hex(ord(payload[7]) * 256 + ord(payload[6]))[2:]) + int(hex(ord(payload[5]))[2:])/100.0
+      if type(payload[0x07]) == int:
+        energy = int(hex(payload[0x07] * 256 + payload[0x06])[2:]) + int(hex(payload[0x05])[2:])/100.0
+      else:
+        energy = int(hex(ord(payload[0x07]) * 256 + ord(payload[0x06]))[2:]) + int(hex(ord(payload[0x05]))[2:])/100.0
       return energy
 
 


### PR DESCRIPTION
I have modified get_energy() in order to support both python2 and python3 same way as all other method do it.

It is different approach than #141 as they added new method specific for only python3.

My solution changes original method in order to support both python 2 & 3