### PR TITLE
Depend on pycryptodome instead of pycrypto

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pycrypto==2.6.1
+pycryptodome==3.4.11

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ try:
     import pyaes
     dynamic_requires = ["pyaes==1.6.0"]
 except ImportError as e:
-    dynamic_requires = ['pycrypto==2.6.1']
+    dynamic_requires = ['pycryptodome==3.4.11']
 
 version = 0.6
 


### PR DESCRIPTION
[PyCrypto](https://github.com/dlitz/pycrypto) has not been updated since June 20, 2014. A fork has been made and is being actively maintained called [pycryptodome](https://github.com/Legrandin/pycryptodome).

PyCrypto also has an unfixed CVE: https://security-tracker.debian.org/tracker/CVE-2013-7459

Since pycryptodome is a drop-in replacement, installing both pycrypto and pycryptodome leads to issues.

And finally the reason why I am opening this PR: with Home Assistant we want to start blocking the installation of pycrypto so we need all our dependencies to migrate to pycryptodome. ([our issue](https://github.com/home-assistant/home-assistant/pull/12715))

I have not tested this change personally as I don't have any broadlink gear. @Danielhiversen, would you be able to test this?