### PR TITLE
Fix for environments where Crypto and pyaes are installed.

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -157,7 +157,7 @@ class device:
     self.type = "Unknown"
     self.lock = threading.Lock()
 
-    if 'pyaes' in sys.modules:
+    if 'pyaes' in globals():
         self.encrypt = self.encrypt_pyaes
         self.decrypt = self.decrypt_pyaes
     else:


### PR DESCRIPTION
If both Crypto and pyaes are installed 'pyaes' is in sys.modules(), but as it is not imported (see top) it's not available.
Fix for #128