### PR TITLE
Add support for Clas Ohlsson OEM branded SP3

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -24,6 +24,8 @@ def gendevice(devtype, host, mac):
     return sp2(host=host, mac=mac, devtype=devtype)
   elif devtype == 0x753e: # SP3
     return sp2(host=host, mac=mac, devtype=devtype)
+  elif devtype == 0x7D00: # OEM branded SP3
+    return sp2(host=host, mac=mac, devtype=devtype)
   elif devtype == 0x947a or devtype == 0x9479: # SP3S
     return sp2(host=host, mac=mac, devtype=devtype)
   elif devtype == 0x2728: # SPMini2


### PR DESCRIPTION
Add "devtype == 0x7D00" to point to a sp2 constructor to add support for the Clas Ohlsson OEM branded SP3 device.