### PR TITLE
Parameters for discovery on multihomed devices.

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -77,7 +77,7 @@ def gendevice(devtype, host, mac):
   else:
     return device(host=host, mac=mac, devtype=devtype)
 
-def discover(timeout=None, local_ip_address=None):
+def discover(timeout=None, local_ip_address=None, broadcast_ip_address=None):
   if local_ip_address is None:
       s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
       s.connect(('8.8.8.8', 53))  # connecting to a UDP address doesn't send packets
@@ -86,10 +86,13 @@ def discover(timeout=None, local_ip_address=None):
   cs = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
   cs.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
   cs.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
-  cs.bind((local_ip_address,0))
+  if broadcast_ip_address is None:
+    cs.bind((local_ip_address,0))
+  else:
+    cs.bind(('',0))
   port = cs.getsockname()[1]
   starttime = time.time()
-
+  
   devices = []
 
   timezone = int(time.timezone/-3600)
@@ -131,7 +134,10 @@ def discover(timeout=None, local_ip_address=None):
   packet[0x20] = checksum & 0xff
   packet[0x21] = checksum >> 8
 
-  cs.sendto(packet, ('255.255.255.255', 80))
+  if broadcast_ip_address is None :
+    cs.sendto(packet, ('255.255.255.255', 80))
+  else:
+    cs.sendto(packet, (broadcast_ip_address, 80))
   if timeout is None:
     response = cs.recvfrom(1024)
     responsepacket = bytearray(response[0])


### PR DESCRIPTION
Add param to allow RPI3 to discover devices when both LAN and wifi are activated.