### PR TITLE
Fixed a bug within the SP2 class.

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -417,10 +417,16 @@ class sp2(device):
     err = response[0x22] | (response[0x23] << 8)
     if err == 0:
       payload = self.decrypt(bytes(response[0x38:]))
-      if ord(payload[0x4]) == 1 or ord(payload[0x4]) == 3:
-        state = True
+      if type(payload[0x4]) == int:
+        if payload[0x4] == 1 or payload[0x4] == 3:
+          state = True
+        else:
+          state = False
       else:
-        state = False
+        if ord(payload[0x4]) == 1 or ord(payload[0x4]) == 3:
+          state = True
+        else:
+          state = False
       return state
 
   def check_nightlight(self):
@@ -431,10 +437,16 @@ class sp2(device):
     err = response[0x22] | (response[0x23] << 8)
     if err == 0:
       payload = self.decrypt(bytes(response[0x38:]))
-      if ord(payload[0x4]) == 2 or ord(payload[0x4]) == 3:
-        state = True
+      if type(payload[0x4]) == int:
+        if payload[0x4] == 2 or payload[0x4] == 3:
+          state = True
+        else:
+          state = False
       else:
-        state = False
+        if ord(payload[0x4]) == 2 or ord(payload[0x4]) == 3:
+          state = True
+        else:
+          state = False
       return state
 
   def get_energy(self):


### PR DESCRIPTION
check_power and check_nightlight did not check to see if the payload was already an int before calling ord.

This fixes the following error:

```
2018-04-15 09:40:00 ERROR (MainThread) [homeassistant.helpers.entity] Update for switch.Lamp fails
Traceback (most recent call last):
  File "/opt/homeassistant/lib/python3.5/site-packages/homeassistant/helpers/entity.py", line 204, in async_update_ha_state
    yield from self.async_device_update()
  File "/opt/homeassistant/lib/python3.5/site-packages/homeassistant/helpers/entity.py", line 327, in async_device_update
    yield from self.hass.async_add_job(self.update)
  File "/usr/lib/python3.5/asyncio/futures.py", line 380, in __iter__
    yield self  # This tells Task to wait for completion.
  File "/usr/lib/python3.5/asyncio/tasks.py", line 304, in _wakeup
    future.result()
  File "/usr/lib/python3.5/asyncio/futures.py", line 293, in result
    raise self._exception
  File "/usr/lib/python3.5/concurrent/futures/thread.py", line 55, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/opt/homeassistant/lib/python3.5/site-packages/homeassistant/components/switch/broadlink.py", line 293, in update
    self._update()
  File "/opt/homeassistant/lib/python3.5/site-packages/homeassistant/components/switch/broadlink.py", line 298, in _update
    state = self._device.check_power()
  File "/opt/homeassistant/lib/python3.5/site-packages/broadlink/__init__.py", line 418, in check_power
    if ord(payload[0x4]) == 1 or ord(payload[0x4]) == 3:
TypeError: ord() expected string of length 1, but int found

```