### PR TITLE
Trivial fix: Change env from python to python2

### DIFF
--- a/cli/broadlink_cli
+++ b/cli/broadlink_cli
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import broadlink
 import sys

--- a/cli/broadlink_discovery
+++ b/cli/broadlink_discovery
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import broadlink
 import time

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 
 import re


### PR DESCRIPTION
This is more explicit and compatible with distributions where python 3
is the default one, such as Arch Linux (it would previously launch the script with python 3, which didn't work).

Would you be open to a further conversion to [python3-compatible code](http://python-future.org/compatible_idioms.html), or even to a total python3 conversion? Python2's EOL is closing by...

Thanks a lot for this great utility, BTW! I spent hours trying to make my SP3 work with official and non-official apps (while being careful not to connect anything to the Internet, and using an old android device with no data on it, as I don't trust official apps and their permissions), to no avail. It took me about 30 seconds to get everything to work with this project.