### PR TITLE
Update vulnerable pycryptodome

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ try:
     import pyaes
     dynamic_requires = ["pyaes==1.6.0"]
 except ImportError as e:
-    dynamic_requires = ['pycryptodome==3.4.11']
+    dynamic_requires = ['pycryptodome==3.6.6']
 
 # For Hysen thermostatic heating controller
 dynamic_requires.append('PyCRC')


### PR DESCRIPTION
This PR is untested!

All pycryptodome versions before 3.6.6 contain vulnerability [CVE-2018-15560](https://www.cvedetails.com/cve/CVE-2018-15560/). This PR bumps the pycryptodome version to 3.6.6 (the latest).

Side effect: fixes #202