### PR TITLE
Fix Dooya curtain (TypeError)

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -815,16 +815,16 @@ class dooya(device):
     err = response[0x22] | (response[0x23] << 8)
     if err == 0:
       payload = self.decrypt(bytes(response[0x38:]))
-      return ord(payload[4])
+      return payload[4]
 
   def open(self):
-    return self._send(0x01, 0x00)
+    return self._send(0x01, 0x00) and self.get_percentage()
 
   def close(self):
-    return self._send(0x02, 0x00)
+    return self._send(0x02, 0x00) and self.get_percentage()
 
   def stop(self):
-    return self._send(0x03, 0x00)
+    return self._send(0x03, 0x00) and self.get_percentage()
 
   def get_percentage(self):
     return self._send(0x06, 0x5d)

--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -53,6 +53,8 @@ def gendevice(devtype, host, mac):
     return a1(host=host, mac=mac)
   elif devtype == 0x4EB5: # MP1
     return mp1(host=host, mac=mac)
+  elif devtype == 0x4E4D: # Dooya DT360E (DOOYA_CURTAIN_V2)
+    return dooya(host=host, mac=mac)
   else:
     return device(host=host, mac=mac)
 
@@ -508,6 +510,52 @@ class rm2(rm):
     dev = discover()
     self.host = dev.host
     self.mac = dev.mac
+
+class dooya(device):
+  def __init__ (self, host, mac):
+    device.__init__(self, host, mac)
+    self.type = "Dooya DT360E"
+
+  def _send(self, magic1, magic2):
+    packet = bytearray(16)
+    packet[0] = 0x09
+    packet[2] = 0xbb
+    packet[3] = magic1
+    packet[4] = magic2
+    packet[9] = 0xfa
+    packet[10] = 0x44
+    response = self.send_packet(0x6a, packet)
+    err = response[0x22] | (response[0x23] << 8)
+    if err == 0:
+      payload = self.decrypt(bytes(response[0x38:]))
+      return ord(payload[4])
+
+  def open(self):
+    return self._send(0x01, 0x00)
+
+  def close(self):
+    return self._send(0x02, 0x00)
+
+  def stop(self):
+    return self._send(0x03, 0x00)
+
+  def get_percentage(self):
+    return self._send(0x06, 0x5d)
+
+  def set_percentage_and_wait(self, new_percentage):
+    current = self.get_percentage()
+    if current > new_percentage:
+      self.close()
+      while current is not None and current > new_percentage:
+        time.sleep(0.2)
+        current = self.get_percentage()
+
+    elif current < new_percentage:
+      self.open()
+      while current is not None and current < new_percentage:
+        time.sleep(0.2)
+        current = self.get_percentage()
+    self.stop()
 
 # Setup a new Broadlink device via AP Mode. Review the README to see how to enter AP Mode.
 # Only tested with Broadlink RM3 Mini (Blackbean)


### PR DESCRIPTION
This should resolve `TypeError: ord() expected string of length 1, but int found` problem.

Tested on my motor with
```
import broadlink

devices = broadlink.discover(5)
devices[0].auth()
print(devices[0].get_percentage()) # tried open/close/stop/set_precentage_and_wait methods
```