### PR TITLE
Bump PyPI package version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,11 +15,11 @@ except ImportError as e:
 # For Hysen thermostatic heating controller
 dynamic_requires.append('PyCRC')
 
-version = 0.9
+version = 0.91
 
 setup(
     name='broadlink',
-    version=0.9,
+    version=0.91,
     author='Matthew Garrett',
     author_email='mjg59@srcf.ucam.org',
     url='http://github.com/mjg59/python-broadlink',


### PR DESCRIPTION
The latest build of this package is still listing pycryptodome 3.4.11 as a dependency. Please trigger a new push so that these changes are reflected there.

I am referring to this commit although I see that there were other commits since the last release as well. https://github.com/mjg59/python-broadlink/commit/8cfa02035381233c148096a319a577e9b3715c6f