### PR TITLE
SP2: Add support for OEM SP2

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -25,7 +25,7 @@ def gendevice(devtype, host, mac):
               0x947a, 0x9479,  # SP3S
               0x2728,  # SPMini2
               0x2733, 0x273e,  # OEM branded SPMini
-              0x7530, 0x7918,  # OEM branded SPMini2
+              0x7530, 0x7546, 0x7918,  # OEM branded SPMini2
               0x7D0D,  # TMall OEM SPMini3
               0x2736  # SPMiniPlus
               ],


### PR DESCRIPTION
Add another OEM SP2 to default sp2 mapping

#### Test screenshot from python shell
![image](https://user-images.githubusercontent.com/6790008/59945351-e7b7cb80-9499-11e9-9ff3-ece900e4dc84.png)
