### PR TITLE
Allow empty auth response key

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -223,7 +223,7 @@ class device:
         payload = self.decrypt(response[0x38:])
 
         if not payload:
-            return False
+            return True
 
         key = payload[0x04:0x14]
         if len(key) % 16 != 0:


### PR DESCRIPTION
Hi, there's people (including me) having issues with the RM Mini 3 with a specific firmware (v44057, doesn't seem to be upgradable/downgradable to v55). I traced the issue down to the response of the auth method:

```bytearray(b"Z\xa5\xaaUZ\xa5\xaaU\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0c\xda\x00\x00*\'\xe9\x03\xc1\xa5\xc8\xf7B\x83f\x00\x00\x00\x00\x00\xd2\xc5\x00\x00V\xb1\xc5\x07\xf1)o\xc2]\xa3\xe4\xa3\xe5u\xd2a\x01\xb0\x14\xdb\xd9\x8dgg#[\x8b\xa1U/\xfc\r")```

This seems to be shorter than the expected result, as it doesn't contain the key as per PROTOCOL.md. I found a couple of issues on this repo related to the addition of this check: #33 #35 #36 #43 , so I'm not sure how to best handle this. Maybe splitting the rmmini3 based on FW version if this is the only one to reply with no key?

Links to issue in HomeAssistant:
- [Failed to connect to device (Broadlink RM Mini3)](https://github.com/home-assistant/home-assistant/issues/23566)
