### PR TITLE
Use old IP address lookup logic as fallback

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -64,6 +64,10 @@ def gendevice(devtype, host, mac):
 def discover(timeout=None, local_ip_address=None):
     if local_ip_address is None:
         local_ip_address = socket.gethostbyname(socket.gethostname())
+    if local_ip_address.startswith('127.'):
+         s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+         s.connect(('8.8.8.8', 53))  # connecting to a UDP address doesn't send packets
+         local_ip_address = s.getsockname()[0]
     address = local_ip_address.split('.')
     cs = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     cs.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)


### PR DESCRIPTION
On some machines, resolving the local hostname results in a loopback IP
address (127.0.0.0/8). This breaks discovery. In these situations, fall
back to the old IP address lookup logic that was removed on commit 790edb9.

---

This fixes the regression introduced in PR #244. Discovery was no longer working for me and I was able to bisect the problem to that commit. This should also fix #270.