### PR TITLE
New rm mini 3 type is introduced by broadlink with a new identifier c…

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -40,7 +40,8 @@ def gendevice(devtype, host, mac):
              0x27a1,  # RM2 Pro Plus R1
              0x27a6,  # RM2 Pro PP
              0x278f,  # RM Mini Shate
-             0x27c2  # RM Mini 3
+             0x27c2,  # RM Mini 3
+             0x27de  # RM Mini 3 (alternate code)
              ],
         a1: [0x2714],  # A1
         mp1: [0x4EB5,  # MP1


### PR DESCRIPTION
I discovered my rm mini 3 has a completely different type code, ox27de. Hoping this would make some people's life easier.