### PR TITLE
Add --joinwifi option to configure the device with Wifi details

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -78,3 +78,8 @@ Get Energy Consumption (For a SmartPlug) :
 ```
 broadlink_cli --device @BEDROOM.device --energy
 ```
+
+Once joined to the Broadlink provisioning Wi-Fi, configure it with your Wi-Fi details:
+```
+broadlink_cli --joinwifi MySSID MyWifiPassword
+```

--- a/cli/broadlink_cli
+++ b/cli/broadlink_cli
@@ -85,6 +85,7 @@ parser.add_argument("--learnfile", help="save learned command to a specified fil
 parser.add_argument("--durations", action="store_true",
                     help="use durations in micro seconds instead of the Broadlink format")
 parser.add_argument("--convert", action="store_true", help="convert input data to durations")
+parser.add_argument("--joinwifi", nargs=2, help="Args are SSID PASSPHRASE to configure Broadlink device with");
 parser.add_argument("data", nargs='*', help="Data to send or convert")
 args = parser.parse_args()
 
@@ -101,6 +102,9 @@ elif args.mac:
 if args.host or args.device:
     dev = broadlink.gendevice(type, (host, 80), mac)
     dev.auth()
+
+if args.joinwifi:
+    broadlink.setup(args.joinwifi[0], args.joinwifi[1], 4)
 
 if args.convert:
     data = bytearray.fromhex(''.join(args.data))


### PR DESCRIPTION
Add option to broadlink_cli to join a specified Wi-Fi network so that fresh devices can be configured onto an existing Wi-Fi network without needing the Android app.