### PR TITLE
FreeBSD can't use 255.255.255.255

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 cryptography==2.6.1
+netifaces==0.10.9


### PR DESCRIPTION
In my FreeBSD 12.1-STABLE on RaspberryPi 3B+, original python-broadlink can't discover my RMmini3.
Raspbian can discover.

FreeBSD default can't send packet to "255.255.255.255", limited broadcast. So calculate directed broadcast for local_ip_address and set it cs.sendto().

Tested on Python 3.7.5 and  3.6.9 from FreeBSD package.