### PR TITLE
Add support for specifying destination IP address to use in discovery

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -61,7 +61,7 @@ def gendevice(devtype, host, mac):
     return device_class(host=host, mac=mac, devtype=devtype)
 
 
-def discover(timeout=None, local_ip_address=None):
+def discover(timeout=None, local_ip_address=None, discover_ip_address='255.255.255.255'):
     if local_ip_address is None:
         local_ip_address = socket.gethostbyname(socket.gethostname())
     if local_ip_address.startswith('127.'):
@@ -117,7 +117,7 @@ def discover(timeout=None, local_ip_address=None):
     packet[0x20] = checksum & 0xff
     packet[0x21] = checksum >> 8
 
-    cs.sendto(packet, ('255.255.255.255', 80))
+    cs.sendto(packet, (discover_ip_address, 80))
     if timeout is None:
         response = cs.recvfrom(1024)
         responsepacket = bytearray(response[0])

--- a/cli/broadlink_discovery
+++ b/cli/broadlink_discovery
@@ -7,10 +7,11 @@ import broadlink
 parser = argparse.ArgumentParser(fromfile_prefix_chars='@')
 parser.add_argument("--timeout", type=int, default=5, help="timeout to wait for receiving discovery responses")
 parser.add_argument("--ip", default=None, help="ip address to use in the discovery")
+parser.add_argument("--dst-ip", default=None, help="destination ip address to use in the discovery")
 args = parser.parse_args()
 
 print("Discovering...")
-devices = broadlink.discover(timeout=args.timeout, local_ip_address=args.ip)
+devices = broadlink.discover(timeout=args.timeout, local_ip_address=args.ip, discover_ip_address=args.dst_ip)
 for device in devices:
     if device.auth():
         print("###########################################")


### PR DESCRIPTION
Add support to specify destination IP for discovery.
Use case: discover device on different network (assuming IP address is known by other means). This allows the device to be on a separate IOT network.