### PR TITLE
Fix CBC mode padding and use adler32 for checksums

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -251,11 +251,10 @@ class device:
         padder = padding.PKCS7(128).padder()
         payload = padder.update(bytes(payload)) + padder.finalize()
         checksum = adler32(payload, 0xbeaf) & 0xffff
-        payload = self.encrypt(payload)
-
         packet[0x34] = checksum & 0xff
         packet[0x35] = checksum >> 8
 
+        payload = self.encrypt(payload)
         for i in range(len(payload)):
             packet.append(payload[i])
 

--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -11,7 +11,6 @@ from datetime import datetime
 from zlib import adler32
 
 from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives import padding
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
 
@@ -248,8 +247,10 @@ class device:
         packet[0x32] = self.id[2]
         packet[0x33] = self.id[3]
 
-        padder = padding.PKCS7(128).padder()
-        payload = padder.update(bytes(payload)) + padder.finalize()
+        # pad the payload for AES encryption
+        if payload:
+            payload += bytearray(((len(payload)-1)//16+1)*16 - len(payload))
+        
         checksum = adler32(payload, 0xbeaf) & 0xffff
         packet[0x34] = checksum & 0xff
         packet[0x35] = checksum >> 8


### PR DESCRIPTION
CBC mode requires a very specific type of padding in which the values in the padded spaces need to match the number of spaces that have been padded. Fortunately, the cryptography module provides a function to save us from these boring details.

I also took the opportunity to use adler32 for checksums. It is easier, faster and improves code readability.