### PR TITLE
Add support for 0x5f36 devices and RM4 series

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -44,9 +44,10 @@ def gendevice(devtype, host, mac):
              0x27a6,  # RM2 Pro PP
              0x278f,  # RM Mini Shate
              0x27c2,  # RM Mini 3
-             0x27d1, #new RM Mini3
-             0x27de,   # RM Mini 3 (C)
-             ],
+             0x27d1,  # new RM Mini3
+             0x27de,  # RM Mini 3 (C)
+             0x5f36  # RM Mini 3
+             ],  
         a1: [0x2714],  # A1
         mp1: [0x4EB5,  # MP1
               0x4EF7  # Honyar oem mp1
@@ -233,8 +234,8 @@ class device:
         packet[0x05] = 0xa5
         packet[0x06] = 0xaa
         packet[0x07] = 0x55
-        packet[0x24] = 0x2a
-        packet[0x25] = 0x27
+        packet[0x24] = self.devtype & 0xff
+        packet[0x25] = self.devtype >> 8
         packet[0x26] = command
         packet[0x28] = self.count & 0xff
         packet[0x29] = self.count >> 8
@@ -251,8 +252,8 @@ class device:
 
         # pad the payload for AES encryption
         if payload:
-            payload += bytearray(((len(payload)-1)//16+1)*16 - len(payload))
-        
+            payload += bytearray(16 - len(payload)%16)
+
         checksum = adler32(payload, 0xbeaf) & 0xffff
         packet[0x34] = checksum & 0xff
         packet[0x35] = checksum >> 8
@@ -571,73 +572,79 @@ class rm(device):
     def __init__(self, host, mac, devtype):
         device.__init__(self, host, mac, devtype)
         self.type = "RM2"
+        if devtype == 0x5f36:
+            self._request_header = b'\x04\x00'
+        else:
+            self._request_header = b''
 
     def check_data(self):
-        packet = bytearray(16)
-        packet[0] = 4
+        packet = bytearray() + self._request_header
+        packet.append(0x04)
         response = self.send_packet(0x6a, packet)
         err = response[0x22] | (response[0x23] << 8)
         if err != 0:
             return None
         payload = self.decrypt(bytes(response[0x38:]))
-        return payload[0x04:]
+        return payload[len(self._request_header) + 4:]
 
     def send_data(self, data):
-        packet = bytearray([0x02, 0x00, 0x00, 0x00])
+        packet = bytearray() + self._request_header
+        packet += bytes([0x02, 0x00, 0x00, 0x00])
         packet += data
         self.send_packet(0x6a, packet)
 
     def enter_learning(self):
-        packet = bytearray(16)
-        packet[0] = 3
+        packet = bytearray() + self._request_header
+        packet.append(0x03)
         self.send_packet(0x6a, packet)
 
     def sweep_frequency(self):
-        packet = bytearray(16)
-        packet[0] = 0x19
+        packet = bytearray() + self._request_header
+        packet.append(0x19)
         self.send_packet(0x6a, packet)
 
     def cancel_sweep_frequency(self):
-        packet = bytearray(16)
-        packet[0] = 0x1e
+        packet = bytearray() + self._request_header
+        packet.append(0x1e)
         self.send_packet(0x6a, packet)
 
     def check_frequency(self):
-        packet = bytearray(16)
-        packet[0] = 0x1a
+        packet = bytearray() + self._request_header
+        packet.append(0x1a)
         response = self.send_packet(0x6a, packet)
         err = response[0x22] | (response[0x23] << 8)
         if err != 0:
             return False
         payload = self.decrypt(bytes(response[0x38:]))
-        if payload[0x04] == 1:
+        if payload[len(self._request_header) + 4] == 1:
             return True
         return False
 
     def find_rf_packet(self):
-        packet = bytearray(16)
-        packet[0] = 0x1b
+        packet = bytearray() + self._request_header
+        packet.append(0x1b)
         response = self.send_packet(0x6a, packet)
         err = response[0x22] | (response[0x23] << 8)
         if err != 0:
             return False
         payload = self.decrypt(bytes(response[0x38:]))
-        if payload[0x04] == 1:
+        if payload[len(self._request_header) + 4] == 1:
             return True
         return False
 
     def check_temperature(self):
-        packet = bytearray(16)
-        packet[0] = 1
+        packet = bytearray() + self._request_header
+        packet.append(0x01)
         response = self.send_packet(0x6a, packet)
         err = response[0x22] | (response[0x23] << 8)
         if err != 0:
             return False
         payload = self.decrypt(bytes(response[0x38:]))
-        if isinstance(payload[0x4], int):
-            temp = (payload[0x4] * 10 + payload[0x5]) / 10.0
+        temp_pos = len(self._request_header) + 4
+        if isinstance(payload[temp_pos], int):
+            temp = (payload[temp_pos] * 10 + payload[temp_pos+1]) / 10.0
         else:
-            temp = (ord(payload[0x4]) * 10 + ord(payload[0x5])) / 10.0
+            temp = (ord(payload[temp_pos]) * 10 + ord(payload[temp_pos+1])) / 10.0
         return temp
 
 

--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -578,7 +578,7 @@ class rm(device):
             self._request_header = b''
 
     def check_data(self):
-        packet = bytearray() + self._request_header
+        packet = bytearray(self._request_header)
         packet.append(0x04)
         response = self.send_packet(0x6a, packet)
         err = response[0x22] | (response[0x23] << 8)
@@ -588,28 +588,28 @@ class rm(device):
         return payload[len(self._request_header) + 4:]
 
     def send_data(self, data):
-        packet = bytearray() + self._request_header
+        packet = bytearray(self._request_header)
         packet += bytes([0x02, 0x00, 0x00, 0x00])
         packet += data
         self.send_packet(0x6a, packet)
 
     def enter_learning(self):
-        packet = bytearray() + self._request_header
+        packet = bytearray(self._request_header)
         packet.append(0x03)
         self.send_packet(0x6a, packet)
 
     def sweep_frequency(self):
-        packet = bytearray() + self._request_header
+        packet = bytearray(self._request_header)
         packet.append(0x19)
         self.send_packet(0x6a, packet)
 
     def cancel_sweep_frequency(self):
-        packet = bytearray() + self._request_header
+        packet = bytearray(self._request_header)
         packet.append(0x1e)
         self.send_packet(0x6a, packet)
 
     def check_frequency(self):
-        packet = bytearray() + self._request_header
+        packet = bytearray(self._request_header)
         packet.append(0x1a)
         response = self.send_packet(0x6a, packet)
         err = response[0x22] | (response[0x23] << 8)
@@ -621,7 +621,7 @@ class rm(device):
         return False
 
     def find_rf_packet(self):
-        packet = bytearray() + self._request_header
+        packet = bytearray(self._request_header)
         packet.append(0x1b)
         response = self.send_packet(0x6a, packet)
         err = response[0x22] | (response[0x23] << 8)
@@ -633,7 +633,7 @@ class rm(device):
         return False
 
     def check_temperature(self):
-        packet = bytearray() + self._request_header
+        packet = bytearray(self._request_header)
         packet.append(0x01)
         response = self.send_packet(0x6a, packet)
         err = response[0x22] | (response[0x23] << 8)

--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -574,8 +574,10 @@ class rm(device):
         self.type = "RM2"
         if devtype == 0x5f36:
             self._request_header = b'\x04\x00'
+            self._code_sending_header = b'\xd0\x00'
         else:
             self._request_header = b''
+            self._code_sending_header = b''
 
     def check_data(self):
         packet = bytearray(self._request_header)
@@ -588,7 +590,7 @@ class rm(device):
         return payload[len(self._request_header) + 4:]
 
     def send_data(self, data):
-        packet = bytearray(self._request_header)
+        packet = bytearray(self._code_sending_header)
         packet += bytes([0x02, 0x00, 0x00, 0x00])
         packet += data
         self.send_packet(0x6a, packet)

--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -205,11 +205,11 @@ class device:
         payload[0x36] = ord('1')
 
         response = self.send_packet(0x65, payload)
-
-        payload = self.decrypt(response[0x38:])
-
-        if not payload:
+        
+        if any(response[0x22:0x24]):
             return False
+        
+        payload = self.decrypt(response[0x38:])
 
         key = payload[0x04:0x14]
         if len(key) % 16 != 0:

--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -147,7 +147,7 @@ class device:
     def __init__(self, host, mac, devtype, timeout=10):
         self.host = host
         self.mac = mac.encode() if isinstance(mac, str) else mac
-        self.devtype = devtype
+        self.devtype = devtype if devtype is not None else 0x272a
         self.timeout = timeout
         self.count = random.randrange(0xffff)
         self.iv = bytearray(
@@ -234,14 +234,8 @@ class device:
         packet[0x05] = 0xa5
         packet[0x06] = 0xaa
         packet[0x07] = 0x55
-
-        if self.devtype is None:
-            packet[0x24] = 0x2a
-            packet[0x25] = 0x27
-        else:
-            packet[0x24] = self.devtype & 0xff
-            packet[0x25] = self.devtype >> 8
-
+        packet[0x24] = self.devtype & 0xff
+        packet[0x25] = self.devtype >> 8
         packet[0x26] = command
         packet[0x28] = self.count & 0xff
         packet[0x29] = self.count >> 8

--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -234,8 +234,14 @@ class device:
         packet[0x05] = 0xa5
         packet[0x06] = 0xaa
         packet[0x07] = 0x55
-        packet[0x24] = self.devtype & 0xff
-        packet[0x25] = self.devtype >> 8
+
+        if self.devtype is None:
+            packet[0x24] = 0x2a
+            packet[0x25] = 0x27
+        else:
+            packet[0x24] = self.devtype & 0xff
+            packet[0x25] = self.devtype >> 8
+
         packet[0x26] = command
         packet[0x28] = self.count & 0xff
         packet[0x29] = self.count >> 8

--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -46,7 +46,9 @@ def gendevice(devtype, host, mac):
              0x27c2,  # RM Mini 3
              0x27d1,  # new RM Mini3
              0x27de,  # RM Mini 3 (C)
-             0x5f36  # RM Mini 3
+             0x51da,  # RM4b
+             0x5f36,  # RM Mini 3
+             0x610f  # RM4c
              ],  
         a1: [0x2714],  # A1
         mp1: [0x4EB5,  # MP1
@@ -572,7 +574,7 @@ class rm(device):
     def __init__(self, host, mac, devtype):
         device.__init__(self, host, mac, devtype)
         self.type = "RM2"
-        if devtype == 0x5f36:
+        if devtype in [0x51da, 0x5f36, 0x610f]:
             self._request_header = b'\x04\x00'
             self._code_sending_header = b'\xd0\x00'
         else:

--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -46,10 +46,12 @@ def gendevice(devtype, host, mac):
              0x27c2,  # RM Mini 3
              0x27d1,  # new RM Mini3
              0x27de,  # RM Mini 3 (C)
-             0x51da,  # RM4b
-             0x5f36,  # RM Mini 3
-             0x610f  # RM4c
-             ],  
+             ],
+        rm4: [0x51da,  # RM4b
+              0x5f36,  # RM Mini 3
+              0x610f,  # RM4c
+              0x62be  # RM4c
+              ],
         a1: [0x2714],  # A1
         mp1: [0x4EB5,  # MP1
               0x4EF7  # Honyar oem mp1
@@ -574,12 +576,8 @@ class rm(device):
     def __init__(self, host, mac, devtype):
         device.__init__(self, host, mac, devtype)
         self.type = "RM2"
-        if devtype in [0x51da, 0x5f36, 0x610f]:
-            self._request_header = b'\x04\x00'
-            self._code_sending_header = b'\xd0\x00'
-        else:
-            self._request_header = b''
-            self._code_sending_header = b''
+        self._request_header = bytes()
+        self._code_sending_header = bytes()
 
     def check_data(self):
         packet = bytearray(self._request_header)
@@ -650,6 +648,14 @@ class rm(device):
         else:
             temp = (ord(payload[temp_pos]) * 10 + ord(payload[temp_pos+1])) / 10.0
         return temp
+
+
+class rm4(rm):
+    def __init__(self, host, mac, devtype):
+        device.__init__(self, host, mac, devtype)
+        self.type = "RM4"
+        self._request_header = b'\x04\x00'
+        self._code_sending_header = b'\xd0\x00'
 
 
 # For legacy compatibility - don't use this

--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -45,7 +45,7 @@ def gendevice(devtype, host, mac):
              0x278f,  # RM Mini Shate
              0x27c2,  # RM Mini 3
              0x27d1,  # new RM Mini3
-             0x27de,  # RM Mini 3 (C)
+             0x27de  # RM Mini 3 (C)
              ],
         rm4: [0x51da,  # RM4b
               0x5f36,  # RM Mini 3


### PR DESCRIPTION
These devices require a special header in the payload. The rest is the same.

## Related issues:
**RM 3 Mini (0x5f36)**
https://github.com/mjg59/python-broadlink/issues/307
https://github.com/mjg59/python-broadlink/issues/308
https://github.com/home-assistant/core/issues/30215
https://github.com/home-assistant/core/issues/23566
https://github.com/lprhodes/homebridge-broadlink-rm/issues/551

**RM4 series**
https://github.com/mjg59/python-broadlink/issues/301
https://github.com/mjg59/python-broadlink/issues/312