### PR TITLE
Add support for RM4 mini with device type 0x610e

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -50,6 +50,7 @@ def gendevice(devtype, host, mac):
         rm4: [0x51da,  # RM4b
               0x5f36,  # RM Mini 3
               0x610f,  # RM4c
+              0x610e,  # RM4 mini
               0x62be  # RM4c
               ],
         a1: [0x2714],  # A1


### PR DESCRIPTION
I have tested this and it working as it should with learning and sending IR codes.