### PR TITLE
Add support for RM4 0x62bc

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -49,8 +49,9 @@ def gendevice(devtype, host, mac, name=None, cloud=None):
              ],
         rm4: [0x51da,  # RM4b
               0x5f36,  # RM Mini 3
-              0x610f,  # RM4c
               0x610e,  # RM4 mini
+              0x610f,  # RM4c
+              0x62bc,  # RM4c
               0x62be  # RM4c
               ],
         a1: [0x2714],  # A1

--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -51,7 +51,7 @@ def gendevice(devtype, host, mac, name=None, cloud=None):
               0x5f36,  # RM Mini 3
               0x610e,  # RM4 mini
               0x610f,  # RM4c
-              0x62bc,  # RM4c
+              0x62bc,  # RM4 mini
               0x62be  # RM4c
               ],
         a1: [0x2714],  # A1


### PR DESCRIPTION
A new type of RM4 mini device has been identified. It works just like the others. 

This PR solves: [RM4 mini 0x62bc](https://github.com/mjg59/python-broadlink/issues/301#issuecomment-606498015)