### PR TITLE
My RM4 mini broadcasts device type 0x62bc

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -51,6 +51,7 @@ def gendevice(devtype, host, mac, name=None, cloud=None):
               0x5f36,  # RM Mini 3
               0x610f,  # RM4c
               0x610e,  # RM4 mini
+              0x62bc,  # RM4 mini
               0x62be  # RM4c
               ],
         a1: [0x2714],  # A1


### PR DESCRIPTION
Using broadlink.discover() I am able to find (and auth with) my RM4 Mini, but it's reporting a device type of 0x62bc, not 0x610e.