### PR TITLE
Fix padding algorithm for CBC mode

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -265,7 +265,7 @@ class device:
 
         # pad the payload for AES encryption
         if payload:
-            payload += bytearray(16 - len(payload)%16)
+            payload += bytearray((16 - len(payload)) % 16)
 
         checksum = adler32(payload, 0xbeaf) & 0xffff
         packet[0x34] = checksum & 0xff


### PR DESCRIPTION
Due to the lack of a parenthesis, the packets were getting 16 bytes larger than necessary.

This PR fixes: https://github.com/mjg59/python-broadlink/issues/338, https://github.com/mjg59/python-broadlink/issues/337 and https://github.com/home-assistant/core/issues/33879.