### PR TITLE
Extend support to RM4 Pro (0x6026)

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -49,9 +49,10 @@ def gendevice(devtype, host, mac, name=None, cloud=None):
              ],
         rm4: [0x51da,  # RM4b
               0x5f36,  # RM Mini 3
-              0x610e,  # RM4 mini
+              0x6026,  # RM4 Pro
+              0x610e,  # RM4 Mini
               0x610f,  # RM4c
-              0x62bc,  # RM4 mini
+              0x62bc,  # RM4 Mini
               0x62be  # RM4c
               ],
         a1: [0x2714],  # A1


### PR DESCRIPTION
A [new type](https://github.com/home-assistant/core/issues/30215#issuecomment-613730859) of RM4 Pro device has been identified. It works just like the others.