### PR TITLE
Add missing "self." to calculate_crc16 uses

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -739,7 +739,7 @@ class hysen(device):
 
     def send_request(self, input_payload):
 
-        crc = calculate_crc16(bytes(input_payload))
+        crc = self.calculate_crc16(bytes(input_payload))
 
         # first byte is length, +2 for CRC16
         request_payload = bytearray([len(input_payload) + 2, 0x00])
@@ -763,7 +763,7 @@ class hysen(device):
         response_payload_len = response_payload[0]
         if response_payload_len + 2 > len(response_payload):
             raise ValueError('hysen_response_error', 'first byte of response is not length')
-        crc = calculate_crc16(bytes(response_payload[2:response_payload_len]))
+        crc = self.calculate_crc16(bytes(response_payload[2:response_payload_len]))
         if (response_payload[response_payload_len] == crc & 0xFF) and (
                 response_payload[response_payload_len + 1] == (crc >> 8) & 0xFF):
             return response_payload[2:response_payload_len]


### PR DESCRIPTION
The current version 0.13.1 breaks the downstream usage of hysen