### PR TITLE
Extend support to RM4c Mini (0x6070)

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -49,6 +49,7 @@ def gendevice(devtype, host, mac, name=None, cloud=None):
         rm4: [0x51da,  # RM4 Mini
               0x5f36,  # RM Mini 3
               0x6026,  # RM4 Pro
+              0x6070,  # RM4c Mini
               0x610e,  # RM4 Mini
               0x610f,  # RM4c
               0x62bc,  # RM4 Mini


### PR DESCRIPTION
A [new type](https://github.com/mjg59/python-broadlink/issues/301#issuecomment-617442260) of RM4c Mini has been identified. It works like the others.