### PR TITLE
Fix 0x62be device name

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -53,7 +53,7 @@ def gendevice(devtype, host, mac, name=None, cloud=None):
               0x610e,  # RM4 Mini
               0x610f,  # RM4c
               0x62bc,  # RM4 Mini
-              0x62be  # RM4c
+              0x62be  # RM4c Mini
               ],
         a1: [0x2714],  # A1
         mp1: [0x4EB5,  # MP1


### PR DESCRIPTION
A user [confirmed](https://github.com/mjg59/python-broadlink/issues/301#issuecomment-619531657) that this is a RM4c Mini.