### PR TITLE
Extend support to RM4 Pro (0x61a2)

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -51,6 +51,7 @@ def gendevice(devtype, host, mac, name=None, cloud=None):
               0x5f36,  # RM Mini 3
               0x6026,  # RM4 Pro
               0x6070,  # RM4c Mini
+              0x61a2,  # RM4 Pro
               0x610e,  # RM4 Mini
               0x610f,  # RM4c
               0x62bc,  # RM4 Mini


### PR DESCRIPTION
A [new type](https://github.com/mjg59/python-broadlink/issues/358#issuecomment-625152269) of RM4 Pro has been identified.