### PR TITLE
Fix error if no dst-ip is provided

### DIFF
--- a/cli/broadlink_discovery
+++ b/cli/broadlink_discovery
@@ -7,7 +7,7 @@ import broadlink
 parser = argparse.ArgumentParser(fromfile_prefix_chars='@')
 parser.add_argument("--timeout", type=int, default=5, help="timeout to wait for receiving discovery responses")
 parser.add_argument("--ip", default=None, help="ip address to use in the discovery")
-parser.add_argument("--dst-ip", default=None, help="destination ip address to use in the discovery")
+parser.add_argument("--dst-ip", default="255.255.255.255", help="destination ip address to use in the discovery")
 args = parser.parse_args()
 
 print("Discovering...")


### PR DESCRIPTION
If not `--dst-ip` is specified when discovering, it gives the below error.

```
Discovering...
Traceback (most recent call last):
  File "./broadlink_discovery", line 14, in <module>
    devices = broadlink.discover(timeout=args.timeout, local_ip_address=args.ip, discover_ip_address=args.dst_ip)
  File "/home/pi/motor/env/lib/python3.7/site-packages/broadlink/__init__.py", line 133, in discover
    cs.sendto(packet, (discover_ip_address, 80))
TypeError: str, bytes or bytearray expected, not NoneType
```
This PR fixes that