### PR TITLE
Fixing RF setup issue

### DIFF
--- a/cli/broadlink_cli
+++ b/cli/broadlink_cli
@@ -126,7 +126,7 @@ if args.send:
     data = durations_to_broadlink(parse_durations(' '.join(args.data))) \
         if args.durations else bytearray.fromhex(''.join(args.data))
     dev.send_data(data)
-if (args.learn or args.learnfile) and not args.rfscanlearn:
+if args.learn or (args.learnfile and not args.rfscanlearn):
     dev.enter_learning()
     data = None
     print("Learning...")
@@ -216,8 +216,6 @@ if args.rfscanlearn:
 
     data = None
     timeout = 20
-
-    time.sleep(10)
 
     while (data is None) and (timeout > 0):
         time.sleep(1)

--- a/cli/broadlink_cli
+++ b/cli/broadlink_cli
@@ -126,7 +126,7 @@ if args.send:
     data = durations_to_broadlink(parse_durations(' '.join(args.data))) \
         if args.durations else bytearray.fromhex(''.join(args.data))
     dev.send_data(data)
-if args.learn or args.learnfile:
+if (args.learn or args.learnfile) and not args.rfscanlearn:
     dev.enter_learning()
     data = None
     print("Learning...")
@@ -216,6 +216,8 @@ if args.rfscanlearn:
 
     data = None
     timeout = 20
+
+    time.sleep(10)
 
     while (data is None) and (timeout > 0):
         time.sleep(1)


### PR DESCRIPTION
May fix issue similar to https://github.com/mjg59/python-broadlink/issues/358 in the cli.  Couldn't get anything to work until I added a pause before pulling data and added logic to skip learning IR if a RF argument had been given. Also had to implement this fix for my specific device https://github.com/mjg59/python-broadlink/pull/360