### PR TITLE
Replace bytes with bytearray

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -603,7 +603,7 @@ class rm(device):
 
     def send_data(self, data):
         packet = bytearray(self._code_sending_header)
-        packet += bytes([0x02, 0x00, 0x00, 0x00])
+        packet += bytearray([0x02, 0x00, 0x00, 0x00])
         packet += data
         response = self.send_packet(0x6a, packet)
         check_error(response[0x22:0x24])


### PR DESCRIPTION
As [pointed out](https://github.com/mjg59/python-broadlink/pull/331#issuecomment-631153914) by @Danny89530, this is necessary to preserve Python 2 support.