### PR TITLE
Add support for SP2-CL (0x7544)

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -26,6 +26,7 @@ def gendevice(devtype, host, mac, name=None, cloud=None):
               0x2728,  # SPMini2
               0x2733, 0x273e,  # OEM branded SPMini
               0x7530, 0x7546, 0x7918,  # OEM branded SPMini2
+              0x7544,  # SP2-CL
               0x7D0D,  # TMall OEM SPMini3
               0x2736  # SPMiniPlus
               ],


### PR DESCRIPTION
A [new type](https://github.com/home-assistant/core/issues/36180#issuecomment-634930309) of SP2 has been identified.

It is important to note that this device does not have a current sensor, so get_energy() will raise a CommandNotSupportedError(). But that's okay, we can handle the exception in the integrations.