### PR TITLE
Fix device discovery

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -77,11 +77,10 @@ def gendevice(devtype, host, mac, name=None, cloud=None):
 
 def discover(timeout=None, local_ip_address=None, discover_ip_address='255.255.255.255'):
     if local_ip_address is None:
-        local_ip_address = socket.gethostbyname(socket.gethostname())
-    if local_ip_address.startswith('127.'):
-        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        s.connect(('8.8.8.8', 53))  # connecting to a UDP address doesn't send packets
-        local_ip_address = s.getsockname()[0]
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+            s.connect(('8.8.8.8', 53))  # connecting to a UDP address doesn't send packets
+            local_ip_address = s.getsockname()[0]
+
     address = local_ip_address.split('.')
     cs = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     cs.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)


### PR DESCRIPTION
### The problem
In May last year [this PR](https://github.com/mjg59/python-broadlink/pull/244) came to define a cleaner logic for the address lookup in `discover()`. The problems did not take long to appear, so in July [this PR](https://github.com/mjg59/python-broadlink/pull/275) proposed using the old logic as a fallback mechanism. This did not fix the first PR completely, and if the initial goal was to make the code cleaner, now we have more code - and more problems.

Why is `socket.gethostbyname(socket.gethostname())` so bad?

1. Platform dependent
A lot of Linux distributions will return 127.0.0.1 and 127.0.1.1, which do not serve as a route to the machine. This was fixed in the second PR, but...

2. Unreliable if the machine has multiple addresses
The result is unpredictable when /etc/hosts defines more than one address for the same machine. This is common when there are multiple network interfaces, such as ethernet and wireless.

3. Unreliable if host not in /etc/hosts
If the host is not in /etc/hosts for some reason, a "Name does not resolve" error will be raised. This is common in Docker containers.

4. Does not work with Home Assistant.
Because of that, `discover()` does not work with Home Assistant. [Check this out](https://github.com/home-assistant/core/issues/30215#issuecomment-635495333).

### Proposed changes
I propose to completely rollback to the old logic, which is the most reliable way to find the local IP address. I also propose using a context manager to close the socket after obtaining the address.