### PR TITLE
Add method for obtaining the firmware version

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -236,7 +236,7 @@ class device:
         return True
 
     def get_fwversion(self):
-        packet = bytearray([104])
+        packet = bytearray([0x68])
         response = self.send_packet(0x6a, packet)
         check_error(response[0x22:0x24])
         payload = self.decrypt(response[0x38:])

--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -235,6 +235,13 @@ class device:
 
         return True
 
+    def get_fwversion(self):
+        packet = bytearray([104])
+        response = self.send_packet(0x6a, packet)
+        check_error(response[0x22:0x24])
+        payload = self.decrypt(response[0x38:])
+        return payload[0x4] | payload[0x5] << 8        
+
     def get_type(self):
         return self.type
 


### PR DESCRIPTION
## Proposed changes
Add a method for obtaining the firmware version. This information is useful for bug checking and is also required to register the device correctly in Home Assistant.

## Tests
Tested on an RM Pro and an RM Mini 3. It would be interesting if someone could help me test this method with other devices, especially RM4 series, which sometimes need special headers for communication.