### PR TITLE
Add method for changing the device name

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -235,6 +235,12 @@ class device:
 
         return True
 
+    def change_name(self, name):
+        packet = bytearray(4)
+        packet.extend(map(ord, name))
+        response = self.send_packet(0x6a, packet)
+        check_error(response[0x22:0x24])
+
     def get_type(self):
         return self.type
 


### PR DESCRIPTION
## Proposed changes
Add a method for changing the device name.

This name appears in the official app. The device always sends its name in HELLO_RESPONSE packets and when we request information (0x6a request with payload 0x1).

## Tests
Tested on an RM Pro and an RM Mini 3. It would be interesting if someone could help me test this method with other devices, especially RM4 series, which sometimes need special headers for communication.