### PR TITLE
Add models and manufacturers

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -111,8 +111,8 @@ def gendevice(devtype, host, mac, name=None, cloud=None):
     try:
         device_class, model, manufacturer = next(
             (device_class, model, manufacturer)
-            for device_class, members in devices.items()
-            for device_type, model, manufacturer in members
+            for device_class, device_list in devices.items()
+            for device_type, model, manufacturer in device_list
             if device_type == devtype
         )
     except StopIteration:

--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -14,114 +14,107 @@ from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
 from .exceptions import check_error, exception
 
+
 def gendevice(devtype, host, mac, name=None, cloud=None):
     devices = {
-        # ~1 == not in Broadlink app
-        # ~2 == not in IHC app
-        # ~3 == not in e-Control app
-
         # Smart Plug
-        sp1: [(0x0000, "SP1", "Broadlink")],  # e-Control app
+        sp1: [(0x0000, "SP1", "Broadlink")],
         sp2: [
-            (0x2711, "SP2", "Broadlink"),  # IHC app
-            (0x2720, "SP mini", "Broadlink"),  # Broadlink app
-            (0x2733, "SP3", "Broadlink (OEM)"),  # Broadlink app / OEM (https://github.com/mjg59/python-broadlink/commit/d490c5b71eaa9fa19f711648a92359678717682f#diff-23bf3ed5c3d3cd55c0dce572ad221c97)
-            (0x753e, "SP mini 3", "Broadlink"),  # Broadlink app  # TODO solve conflict: SP3 (https://github.com/mjg59/python-broadlink/commit/d490c5b71eaa9fa19f711648a92359678717682f#diff-23bf3ed5c3d3cd55c0dce572ad221c97)
-            (0x7546, "SP2-UK/BR/IN", "Broadlink (OEM)"),  # Broadlink app / OEM (https://github.com/mjg59/python-broadlink/pull/251)
-            (0x7d00, "SP3-EU", "Broadlink (OEM)"),  # IHC app (Brand: Clas Ohlson) / OEM (https://github.com/mjg59/python-broadlink/pull/169)
-            (0x7d0d, "SP mini 3", "Broadlink (OEM)"),  # IHC app / OEM (https://github.com/mjg59/python-broadlink/pull/228)
-            (0x9479, "SP3S-US", "Broadlink"),  # Broadlink app
-            (0x947a, "SP3S-EU", "Broadlink"),  # Broadlink app
-
-            # TODO REVIEW
-            (0x2719, "SP2-compatible", "Honeywell"),  # e-Control app  # TODO get model / confirm (https://github.com/mjg59/python-broadlink/commit/d490c5b71eaa9fa19f711648a92359678717682f#diff-23bf3ed5c3d3cd55c0dce572ad221c97)
-            (0x2728, "SP2-compatible", "URANT/Kebidu"),  # TODO solve conflicts: URANT SP1-UK (IHC app) != SP mini (e-Control app) != Kebidu KBT001929-EU (https://github.com/mjg59/python-broadlink/issues/135)
-            (0x271a, "SP2-compatible", "Honeywell"),  # e-Control app  # TODO get model / confirm (https://github.com/mjg59/python-broadlink/commit/d490c5b71eaa9fa19f711648a92359678717682f#diff-23bf3ed5c3d3cd55c0dce572ad221c97)
-            (0x2736, "SP mini plus", "Broadlink (OEM)"),  # e-Control app  # TODO does SP mini plus exist? confirm (https://github.com/mjg59/python-broadlink/commit/d490c5b71eaa9fa19f711648a92359678717682f#diff-23bf3ed5c3d3cd55c0dce572ad221c97)
-            (0x273e, "SP mini", "Broadlink (OEM)"),  # ~1 ~2 ~3  # TODO confirm (https://github.com/mjg59/python-broadlink/commit/d490c5b71eaa9fa19f711648a92359678717682f#diff-23bf3ed5c3d3cd55c0dce572ad221c97)
-            (0x7530, "SP mini 2", "Broadlink (OEM)"), # e-Control app  # TODO does SP mini 2 exist? confirm (https://github.com/mjg59/python-broadlink/commit/d490c5b71eaa9fa19f711648a92359678717682f#diff-23bf3ed5c3d3cd55c0dce572ad221c97)
-            (0x7918, "SP mini 2", "Broadlink (OEM)"),  # e-Control app  # TODO dost SP mini 2 exist? confirm (https://github.com/mjg59/python-broadlink/commit/d490c5b71eaa9fa19f711648a92359678717682f#diff-23bf3ed5c3d3cd55c0dce572ad221c97)
-            (0x7919, "SP2-compatible", "Broadlink (OEM)/Honeywell"),  # TODO solve conflicts: Broadlink WS1-W10 (IHC app) != SP mini (e-Control app) != Honeywell (https://github.com/mjg59/python-broadlink/commit/d490c5b71eaa9fa19f711648a92359678717682f#diff-23bf3ed5c3d3cd55c0dce572ad221c97)
-            (0x791a, "SP2-compatible", "Broadlink (OEM)/Honeywell"),  # TODO solve conflicts: Broadlink WS1-W16 (IHC app) != SP mini (e-Control app) != Honeywell (https://github.com/mjg59/python-broadlink/commit/d490c5b71eaa9fa19f711648a92359678717682f#diff-23bf3ed5c3d3cd55c0dce572ad221c97)
+            (0x2711, "SP2", "Broadlink"),
+            (0x2719, "SP2-compatible", "Honeywell"),
+            (0x271a, "SP2-compatible", "Honeywell"),
+            (0x2720, "SP mini", "Broadlink"),
+            (0x2728, "SP2-compatible", "URANT"),
+            (0x2733, "SP3", "Broadlink"),
+            (0x2736, "SP mini+", "Broadlink"),
+            (0x273e, "SP mini", "Broadlink"),
+            (0x7530, "SP2", "Broadlink (OEM)"),
+            (0x753e, "SP mini 3", "Broadlink"),
+            (0x7546, "SP2-UK/BR/IN", "Broadlink (OEM)"),
+            (0x7918, "SP2", "Broadlink (OEM)"),
+            (0x7919, "SP2-compatible", "Honeywell"),
+            (0x791a, "SP2-compatible", "Honeywell"),
+            (0x7d00, "SP3-EU", "Broadlink (OEM)"),
+            (0x7d0d, "SP mini 3", "Broadlink (OEM)"),
+            (0x9479, "SP3S-US", "Broadlink"),
+            (0x947a, "SP3S-EU", "Broadlink"),
         ],
 
         # Universal Remote
         rm: [
-            (0x2712, "RM pro/pro+", "Broadlink"),  # Broadlink app
-            (0x272a, "RM pro", "Broadlink"),  # Broadlink app
-            (0x2737, "RM mini 3", "Broadlink"),  # Broadlink app
-            (0x277c, "RM home", "Broadlink (OEM)"),  # IHC app
-            (0x2783, "RM home", "Broadlink"),  # Broadlink app
-            (0x2787, "RM pro", "Broadlink"),  # Broadlink app
-            (0x278b, "RM plus", "Broadlink (OEM)"),  # IHC app
-            (0x2797, "RM pro+", "Broadlink"),  # Broadlink app
-            (0x279d, "RM pro+", "Broadlink"),  # Broadlink app
-            (0x27a9, "RM pro+", "Broadlink"),  # Broadlink app
-            (0x27c2, "RM mini 3", "Broadlink (OEM)"),  # IHC app
-            (0x27d1, "RM mini 3", "Broadlink (OEM)"),  # IHC app
-            (0x27de, "RM mini 3", "Broadlink"),  # Broadlink app
-
-            # TODO REVIEW
-            (0x273d, "RM pro", "Broadlink (OEM)"),  # ~1 ~2 ~3  # TODO confirm: RM Pro Phicomm (https://github.com/mjg59/python-broadlink/commit/d490c5b71eaa9fa19f711648a92359678717682f#diff-23bf3ed5c3d3cd55c0dce572ad221c97)
-            (0x278f, "RM mini", "Broadlink (OEM)"),  # ~1 ~2 ~3  # TODO confirm: RM Mini Shate (https://github.com/mjg59/python-broadlink/commit/d490c5b71eaa9fa19f711648a92359678717682f#diff-23bf3ed5c3d3cd55c0dce572ad221c97)
-            (0x27a1, "RM plus", "Broadlink (OEM)"),  # TODO solve conflicts: RM2 Pro Plus R1 (https://github.com/mjg59/python-broadlink/pull/156) != SP1 (e-Control app)
-            (0x27a6, "RM plus", "Broadlink (OEM)"),  # ~1 ~2 ~3  # TODO confirm RM2 Pro PP (https://github.com/mjg59/python-broadlink/pull/156)
+            (0x2712, "RM pro/pro+", "Broadlink"),
+            (0x272a, "RM pro", "Broadlink"),
+            (0x273d, "RM pro", "Broadlink"),
+            (0x2737, "RM mini 3", "Broadlink"),
+            (0x277c, "RM home", "Broadlink"),
+            (0x2783, "RM home", "Broadlink"),
+            (0x2787, "RM pro", "Broadlink"),
+            (0x278b, "RM plus", "Broadlink"),
+            (0x278f, "RM mini", "Broadlink"),
+            (0x2797, "RM pro+", "Broadlink"),
+            (0x279d, "RM pro+", "Broadlink"),
+            (0x27a1, "RM plus", "Broadlink"),
+            (0x27a6, "RM plus", "Broadlink"),
+            (0x27a9, "RM pro+", "Broadlink"),
+            (0x27c2, "RM mini 3", "Broadlink"),
+            (0x27d1, "RM mini 3", "Broadlink"),
+            (0x27de, "RM mini 3", "Broadlink"),
         ],
         rm4: [
-            (0x51da, "RM4 mini", "Broadlink"),  # Broadlink app
-            (0x5f36, "RM mini", "Broadlink"),  # Broadlink app
-            (0x6026, "RM4 pro", "Broadlink"),  # Broadlink app
-            (0x6070, "RM4C mini", "Broadlink"),  # Broadlink app
-            (0x610e, "RM4 mini", "Broadlink"),  # Broadlink app
-            (0x610f, "RM4C mini", "Broadlink"),  # Broadlink app
-            (0x61a2, "RM4 pro", "Broadlink"),  # Broadlink app
-            (0x62bc, "RM4 mini", "Broadlink"),  # Broadlink app
-            (0x62be, "RM4C mini", "Broadlink"),  # Broadlink app
+            (0x51da, "RM4 mini", "Broadlink"),
+            (0x5f36, "RM mini", "Broadlink"),
+            (0x6026, "RM4 pro", "Broadlink"),
+            (0x6070, "RM4C mini", "Broadlink"),
+            (0x610e, "RM4 mini", "Broadlink"),
+            (0x610f, "RM4C mini", "Broadlink"),
+            (0x61a2, "RM4 pro", "Broadlink"),
+            (0x62bc, "RM4 mini", "Broadlink"),
+            (0x62be, "RM4C mini", "Broadlink"),
         ],
 
         # e-Sensor
-        a1: [(0x2714, "e-Sensor", "Broadlink")],  # Broadlink app
+        a1: [(0x2714, "e-Sensor", "Broadlink")],
 
         # Power Strip
         mp1: [
-            (0x4eb5, "Broadlink", "MP1-1K4S"),
-            (0x4ef7, "Broadlink (OEM)", "MP1-1K4S"),  # ~1 ~2 ~3 / Brand: Honyar (https://github.com/mjg59/python-broadlink/commit/1d7fba3d06af33b6af3d51b87a5c66c32751433d#diff-8651c630cb85a737f3c4c67091ea485f)
+            (0x4eb5, "MP1-1K4S", "Broadlink"),
+            (0x4ef7, "MP1-1K4S", "Broadlink (OEM)"),
         ],
 
         # HVAC
-        hysen: [(0x4ead, "HY02B05H", "Hysen")],  # IHC app  # TODO the model came from (https://github.com/mjg59/python-broadlink/pull/138), the apps shows "HVAC"
+        hysen: [(0x4ead, "HY02B05H", "Hysen")],
 
         # Wi-Fi Alarm Kit
-        S1C: [(0x2722, "S2KIT", "Broadlink")],  # Broadlink app  # TODO solve conflicts: S2KIT (Broadlink app) != S1C (https://github.com/mjg59/python-broadlink/pull/103)
+        S1C: [(0x2722, "S2KIT", "Broadlink")],
 
         # Electric Curtain Motor
-        dooya: [(0x4e4d, "DT360E-45/20", "Dooya")],  # Broadlink app
+        dooya: [(0x4e4d, "DT360E-45/20", "Dooya")],
 
         # Wall Socket
-        bg1: [(0x51e3, "BG800/BG900", "BG Electrical")],  # BG app  # TODO: these models came from users, the app shows "Socket"
+        bg1: [(0x51e3, "BG800/BG900", "BG Electrical")],
 
         # Smart Bulb
         lb1: [
-            (0x5043, "SB800TD", "Broadlink (OEM)"),  # Broadlink app
-            (0x60c8, "LB1", "Broadlink (OEM)"),  # ~1 ~2 ~3  # TODO find model
+            (0x5043, "SB800TD", "Broadlink (OEM)"),
+            (0x60c8, "LB1", "Broadlink (OEM)"),
         ],
     }
 
     # Look for the class associated to devtype in devices
     try:
-        device_class, model, manufacturer = next(
-            (device_class, model, manufacturer)
-            for device_class, device_list in devices.items()
-            for device_type, model, manufacturer in device_list
-            if device_type == devtype
+        dev_class, model, manufacturer = next(
+            (dev_class, model, manufacturer)
+            for dev_class, dev_list in devices.items()
+            for dev_type, model, manufacturer in dev_list
+            if dev_type == devtype
         )
     except StopIteration:
         return device(host, mac, devtype, name=name, cloud=cloud)
 
-    device = device_class(host, mac, devtype, name=name, cloud=cloud)
-    device.model = model
-    device.manufacturer = manufacturer
-    return device
+    dev = dev_class(host, mac, devtype, name=name, cloud=cloud)
+    dev.model = model
+    dev.manufacturer = manufacturer
+    return dev
 
 
 def discover(timeout=None, local_ip_address=None, discover_ip_address='255.255.255.255'):

--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -31,6 +31,7 @@ def gendevice(devtype, host, mac, name=None, cloud=None):
         0x273e: (sp2, "SP mini", "Broadlink"),
         0x7530: (sp2, "SP2", "Broadlink (OEM)"),
         0x753e: (sp2, "SP mini 3", "Broadlink"),
+        0X7544: (sp2, "SP2-CL", "Broadlink"),
         0x7546: (sp2, "SP2-UK/BR/IN", "Broadlink (OEM)"),
         0x7918: (sp2, "SP2", "Broadlink (OEM)"),
         0x7919: (sp2, "SP2-compatible", "Honeywell"),

--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -40,8 +40,8 @@ def gendevice(devtype, host, mac, name=None, cloud=None):
 
         0x2712: (rm, "RM pro/pro+", "Broadlink"),
         0x272a: (rm, "RM pro", "Broadlink"),
-        0x273d: (rm, "RM pro", "Broadlink"),
         0x2737: (rm, "RM mini 3", "Broadlink"),
+        0x273d: (rm, "RM pro", "Broadlink"),
         0x277c: (rm, "RM home", "Broadlink"),
         0x2783: (rm, "RM home", "Broadlink"),
         0x2787: (rm, "RM pro", "Broadlink"),
@@ -70,6 +70,7 @@ def gendevice(devtype, host, mac, name=None, cloud=None):
 
         0x4eb5: (mp1, "MP1-1K4S", "Broadlink"),
         0x4ef7: (mp1, "MP1-1K4S", "Broadlink (OEM)"),
+        0x4f65: (mp1, "MP1-1K3S2U", "Broadlink"),
 
         0x4ead: (hysen, "HY02B05H", "Hysen"),
 
@@ -80,6 +81,7 @@ def gendevice(devtype, host, mac, name=None, cloud=None):
         0x51e3: (bg1, "BG800/BG900", "BG Electrical"),
 
         0x5043: (lb1, "SB800TD", "Broadlink (OEM)"),
+        0x60c7: (lb1, "LB1", "Broadlink (OEM)"),
         0x60c8: (lb1, "LB1", "Broadlink (OEM)"),
     }
 

--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -74,17 +74,19 @@ def gendevice(devtype, host, mac, name=None, cloud=None):
         0x4ef7: (mp1, "MP1-1K4S", "Broadlink (OEM)"),
         0x4f65: (mp1, "MP1-1K3S2U", "Broadlink"),
 
-        0x4ead: (hysen, "HY02B05H", "Hysen"),
+        0x5043: (lb1, "SB800TD", "Broadlink (OEM)"),
+        0x504e: (lb1, "LB1", "Broadlink"),
+        0x60c7: (lb1, "LB1", "Broadlink"),
+        0x60c8: (lb1, "LB1", "Broadlink"),
+        0x6112: (lb1, "LB1", "Broadlink"),
 
         0x2722: (S1C, "S2KIT", "Broadlink"),
+
+        0x4ead: (hysen, "HY02B05H", "Hysen"),
 
         0x4e4d: (dooya, "DT360E-45/20", "Dooya"),
 
         0x51e3: (bg1, "BG800/BG900", "BG Electrical"),
-
-        0x5043: (lb1, "SB800TD", "Broadlink (OEM)"),
-        0x60c7: (lb1, "LB1", "Broadlink (OEM)"),
-        0x60c8: (lb1, "LB1", "Broadlink (OEM)"),
     }
 
     # Look for the class associated to devtype in devices

--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -16,64 +16,112 @@ from .exceptions import check_error, exception
 
 def gendevice(devtype, host, mac, name=None, cloud=None):
     devices = {
-        sp1: [0],
-        sp2: [0x2711,  # SP2
-              0x2719, 0x7919, 0x271a, 0x791a,  # Honeywell SP2
-              0x2720,  # SPMini
-              0x753e,  # SP3
-              0x7D00,  # OEM branded SP3
-              0x947a, 0x9479,  # SP3S
-              0x2728,  # SPMini2
-              0x2733, 0x273e,  # OEM branded SPMini
-              0x7530, 0x7546, 0x7918,  # OEM branded SPMini2
-              0x7544,  # SP2-CL
-              0x7D0D,  # TMall OEM SPMini3
-              0x2736  # SPMiniPlus
-              ],
-        rm: [0x2712,  # RM2
-             0x2737,  # RM Mini
-             0x273d,  # RM Pro Phicomm
-             0x2783,  # RM2 Home Plus
-             0x277c,  # RM2 Home Plus GDT
-             0x272a,  # RM2 Pro Plus
-             0x2787,  # RM2 Pro Plus2
-             0x279d,  # RM2 Pro Plus3
-             0x27a9,  # RM2 Pro Plus_300
-             0x278b,  # RM2 Pro Plus BL
-             0x2797,  # RM2 Pro Plus HYC
-             0x27a1,  # RM2 Pro Plus R1
-             0x27a6,  # RM2 Pro PP
-             0x278f,  # RM Mini Shate
-             0x27c2,  # RM Mini 3
-             0x27d1,  # new RM Mini3
-             0x27de  # RM Mini 3 (C)
-             ],
-        rm4: [0x51da,  # RM4 Mini
-              0x5f36,  # RM Mini 3
-              0x6026,  # RM4 Pro
-              0x6070,  # RM4c Mini
-              0x61a2,  # RM4 Pro
-              0x610e,  # RM4 Mini
-              0x610f,  # RM4c
-              0x62bc,  # RM4 Mini
-              0x62be  # RM4c Mini
-              ],
-        a1: [0x2714],  # A1
-        mp1: [0x4EB5,  # MP1
-              0x4EF7  # Honyar oem mp1
-              ],
-        hysen: [0x4EAD],  # Hysen controller
-        S1C: [0x2722],  # S1 (SmartOne Alarm Kit)
-        dooya: [0x4E4D],  # Dooya DT360E (DOOYA_CURTAIN_V2)
-        bg1: [0x51E3], # BG Electrical Smart Power Socket
-        lb1 : [0x60c8]   # RGB Smart Bulb
+        # ~1 == not in Broadlink app
+        # ~2 == not in IHC app
+        # ~3 == not in e-Control app
+
+        # Smart Plug
+        sp1: [(0x0000, "SP1", "Broadlink")],  # e-Control app
+        sp2: [
+            (0x2711, "SP2", "Broadlink"),  # IHC app
+            (0x2720, "SP mini", "Broadlink"),  # Broadlink app
+            (0x2733, "SP3", "Broadlink (OEM)"),  # Broadlink app / OEM (https://github.com/mjg59/python-broadlink/commit/d490c5b71eaa9fa19f711648a92359678717682f#diff-23bf3ed5c3d3cd55c0dce572ad221c97)
+            (0x753e, "SP mini 3", "Broadlink"),  # Broadlink app  # TODO solve conflict: SP3 (https://github.com/mjg59/python-broadlink/commit/d490c5b71eaa9fa19f711648a92359678717682f#diff-23bf3ed5c3d3cd55c0dce572ad221c97)
+            (0x7546, "SP2-UK/BR/IN", "Broadlink (OEM)"),  # Broadlink app / OEM (https://github.com/mjg59/python-broadlink/pull/251)
+            (0x7d00, "SP3-EU", "Broadlink (OEM)"),  # IHC app (Brand: Clas Ohlson) / OEM (https://github.com/mjg59/python-broadlink/pull/169)
+            (0x7d0d, "SP mini 3", "Broadlink (OEM)"),  # IHC app / OEM (https://github.com/mjg59/python-broadlink/pull/228)
+            (0x9479, "SP3S-US", "Broadlink"),  # Broadlink app
+            (0x947a, "SP3S-EU", "Broadlink"),  # Broadlink app
+
+            # TODO REVIEW
+            (0x2719, "SP2-compatible", "Honeywell"),  # e-Control app  # TODO get model / confirm (https://github.com/mjg59/python-broadlink/commit/d490c5b71eaa9fa19f711648a92359678717682f#diff-23bf3ed5c3d3cd55c0dce572ad221c97)
+            (0x2728, "SP2-compatible", "URANT/Kebidu"),  # TODO solve conflicts: URANT SP1-UK (IHC app) != SP mini (e-Control app) != Kebidu KBT001929-EU (https://github.com/mjg59/python-broadlink/issues/135)
+            (0x271a, "SP2-compatible", "Honeywell"),  # e-Control app  # TODO get model / confirm (https://github.com/mjg59/python-broadlink/commit/d490c5b71eaa9fa19f711648a92359678717682f#diff-23bf3ed5c3d3cd55c0dce572ad221c97)
+            (0x2736, "SP mini plus", "Broadlink (OEM)"),  # e-Control app  # TODO does SP mini plus exist? confirm (https://github.com/mjg59/python-broadlink/commit/d490c5b71eaa9fa19f711648a92359678717682f#diff-23bf3ed5c3d3cd55c0dce572ad221c97)
+            (0x273e, "SP mini", "Broadlink (OEM)"),  # ~1 ~2 ~3  # TODO confirm (https://github.com/mjg59/python-broadlink/commit/d490c5b71eaa9fa19f711648a92359678717682f#diff-23bf3ed5c3d3cd55c0dce572ad221c97)
+            (0x7530, "SP mini 2", "Broadlink (OEM)"), # e-Control app  # TODO does SP mini 2 exist? confirm (https://github.com/mjg59/python-broadlink/commit/d490c5b71eaa9fa19f711648a92359678717682f#diff-23bf3ed5c3d3cd55c0dce572ad221c97)
+            (0x7918, "SP mini 2", "Broadlink (OEM)"),  # e-Control app  # TODO dost SP mini 2 exist? confirm (https://github.com/mjg59/python-broadlink/commit/d490c5b71eaa9fa19f711648a92359678717682f#diff-23bf3ed5c3d3cd55c0dce572ad221c97)
+            (0x7919, "SP2-compatible", "Broadlink (OEM)/Honeywell"),  # TODO solve conflicts: Broadlink WS1-W10 (IHC app) != SP mini (e-Control app) != Honeywell (https://github.com/mjg59/python-broadlink/commit/d490c5b71eaa9fa19f711648a92359678717682f#diff-23bf3ed5c3d3cd55c0dce572ad221c97)
+            (0x791a, "SP2-compatible", "Broadlink (OEM)/Honeywell"),  # TODO solve conflicts: Broadlink WS1-W16 (IHC app) != SP mini (e-Control app) != Honeywell (https://github.com/mjg59/python-broadlink/commit/d490c5b71eaa9fa19f711648a92359678717682f#diff-23bf3ed5c3d3cd55c0dce572ad221c97)
+        ],
+
+        # Universal Remote
+        rm: [
+            (0x2712, "RM pro/pro+", "Broadlink"),  # Broadlink app
+            (0x272a, "RM pro", "Broadlink"),  # Broadlink app
+            (0x2737, "RM mini 3", "Broadlink"),  # Broadlink app
+            (0x277c, "RM home", "Broadlink (OEM)"),  # IHC app
+            (0x2783, "RM home", "Broadlink"),  # Broadlink app
+            (0x2787, "RM pro", "Broadlink"),  # Broadlink app
+            (0x278b, "RM plus", "Broadlink (OEM)"),  # IHC app
+            (0x2797, "RM pro+", "Broadlink"),  # Broadlink app
+            (0x279d, "RM pro+", "Broadlink"),  # Broadlink app
+            (0x27a9, "RM pro+", "Broadlink"),  # Broadlink app
+            (0x27c2, "RM mini 3", "Broadlink (OEM)"),  # IHC app
+            (0x27d1, "RM mini 3", "Broadlink (OEM)"),  # IHC app
+            (0x27de, "RM mini 3", "Broadlink"),  # Broadlink app
+
+            # TODO REVIEW
+            (0x273d, "RM pro", "Broadlink (OEM)"),  # ~1 ~2 ~3  # TODO confirm: RM Pro Phicomm (https://github.com/mjg59/python-broadlink/commit/d490c5b71eaa9fa19f711648a92359678717682f#diff-23bf3ed5c3d3cd55c0dce572ad221c97)
+            (0x278f, "RM mini", "Broadlink (OEM)"),  # ~1 ~2 ~3  # TODO confirm: RM Mini Shate (https://github.com/mjg59/python-broadlink/commit/d490c5b71eaa9fa19f711648a92359678717682f#diff-23bf3ed5c3d3cd55c0dce572ad221c97)
+            (0x27a1, "RM plus", "Broadlink (OEM)"),  # TODO solve conflicts: RM2 Pro Plus R1 (https://github.com/mjg59/python-broadlink/pull/156) != SP1 (e-Control app)
+            (0x27a6, "RM plus", "Broadlink (OEM)"),  # ~1 ~2 ~3  # TODO confirm RM2 Pro PP (https://github.com/mjg59/python-broadlink/pull/156)
+        ],
+        rm4: [
+            (0x51da, "RM4 mini", "Broadlink"),  # Broadlink app
+            (0x5f36, "RM mini", "Broadlink"),  # Broadlink app
+            (0x6026, "RM4 pro", "Broadlink"),  # Broadlink app
+            (0x6070, "RM4C mini", "Broadlink"),  # Broadlink app
+            (0x610e, "RM4 mini", "Broadlink"),  # Broadlink app
+            (0x610f, "RM4C mini", "Broadlink"),  # Broadlink app
+            (0x61a2, "RM4 pro", "Broadlink"),  # Broadlink app
+            (0x62bc, "RM4 mini", "Broadlink"),  # Broadlink app
+            (0x62be, "RM4C mini", "Broadlink"),  # Broadlink app
+        ],
+
+        # e-Sensor
+        a1: [(0x2714, "e-Sensor", "Broadlink")],  # Broadlink app
+
+        # Power Strip
+        mp1: [
+            (0x4eb5, "Broadlink", "MP1-1K4S"),
+            (0x4ef7, "Broadlink (OEM)", "MP1-1K4S"),  # ~1 ~2 ~3 / Brand: Honyar (https://github.com/mjg59/python-broadlink/commit/1d7fba3d06af33b6af3d51b87a5c66c32751433d#diff-8651c630cb85a737f3c4c67091ea485f)
+        ],
+
+        # HVAC
+        hysen: [(0x4ead, "HY02B05H", "Hysen")],  # IHC app  # TODO the model came from (https://github.com/mjg59/python-broadlink/pull/138), the apps shows "HVAC"
+
+        # Wi-Fi Alarm Kit
+        S1C: [(0x2722, "S2KIT", "Broadlink")],  # Broadlink app  # TODO solve conflicts: S2KIT (Broadlink app) != S1C (https://github.com/mjg59/python-broadlink/pull/103)
+
+        # Electric Curtain Motor
+        dooya: [(0x4e4d, "DT360E-45/20", "Dooya")],  # Broadlink app
+
+        # Wall Socket
+        bg1: [(0x51e3, "BG800/BG900", "BG Electrical")],  # BG app  # TODO: these models came from users, the app shows "Socket"
+
+        # Smart Bulb
+        lb1: [
+            (0x5043, "SB800TD", "Broadlink (OEM)"),  # Broadlink app
+            (0x60c8, "LB1", "Broadlink (OEM)"),  # ~1 ~2 ~3  # TODO find model
+        ],
     }
 
     # Look for the class associated to devtype in devices
-    [device_class] = [dev for dev in devices if devtype in devices[dev]] or [None]
-    if device_class is None:
+    try:
+        device_class, model, manufacturer = next(
+            (device_class, model, manufacturer)
+            for device_class, members in devices.items()
+            for device_type, model, manufacturer in members
+            if device_type == devtype
+        )
+    except StopIteration:
         return device(host, mac, devtype, name=name, cloud=cloud)
-    return device_class(host, mac, devtype, name=name, cloud=cloud)
+
+    device = device_class(host, mac, devtype, name=name, cloud=cloud)
+    device.model = model
+    device.manufacturer = manufacturer
+    return device
 
 
 def discover(timeout=None, local_ip_address=None, discover_ip_address='255.255.255.255'):
@@ -170,6 +218,8 @@ class device:
         self.devtype = devtype if devtype is not None else 0x272a
         self.name = name
         self.cloud = cloud
+        self.model = None
+        self.manufacturer = None
         self.timeout = timeout
         self.count = random.randrange(0xffff)
         self.iv = bytearray(

--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -8,6 +8,7 @@ import struct
 import threading
 import time
 from datetime import datetime
+from functools import lru_cache
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
@@ -15,6 +16,7 @@ from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from .exceptions import check_error, exception
 
 
+@lru_cache(64)
 def gendevice(devtype, host, mac, name=None, cloud=None):
     devices = {
         0x0000: (sp1, "SP1", "Broadlink"),
@@ -1011,8 +1013,8 @@ class lb1(device):
                         'color jumping' : 6,
                         'multicolor jumping' : 7 }
 
-    def __init__(self, host, mac, devtype):
-        device.__init__(self, host, mac, devtype)
+    def __init__(self, *args, **kwargs):
+        device.__init__(self, *args, **kwargs)
         self.type = "SmartBulb"
 
     def send_command(self,command, type = 'set'):

--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -17,98 +17,76 @@ from .exceptions import check_error, exception
 
 def gendevice(devtype, host, mac, name=None, cloud=None):
     devices = {
-        # Smart Plug
-        sp1: [(0x0000, "SP1", "Broadlink")],
-        sp2: [
-            (0x2711, "SP2", "Broadlink"),
-            (0x2719, "SP2-compatible", "Honeywell"),
-            (0x271a, "SP2-compatible", "Honeywell"),
-            (0x2720, "SP mini", "Broadlink"),
-            (0x2728, "SP2-compatible", "URANT"),
-            (0x2733, "SP3", "Broadlink"),
-            (0x2736, "SP mini+", "Broadlink"),
-            (0x273e, "SP mini", "Broadlink"),
-            (0x7530, "SP2", "Broadlink (OEM)"),
-            (0x753e, "SP mini 3", "Broadlink"),
-            (0x7546, "SP2-UK/BR/IN", "Broadlink (OEM)"),
-            (0x7918, "SP2", "Broadlink (OEM)"),
-            (0x7919, "SP2-compatible", "Honeywell"),
-            (0x791a, "SP2-compatible", "Honeywell"),
-            (0x7d00, "SP3-EU", "Broadlink (OEM)"),
-            (0x7d0d, "SP mini 3", "Broadlink (OEM)"),
-            (0x9479, "SP3S-US", "Broadlink"),
-            (0x947a, "SP3S-EU", "Broadlink"),
-        ],
+        0x0000: (sp1, "SP1", "Broadlink"),
 
-        # Universal Remote
-        rm: [
-            (0x2712, "RM pro/pro+", "Broadlink"),
-            (0x272a, "RM pro", "Broadlink"),
-            (0x273d, "RM pro", "Broadlink"),
-            (0x2737, "RM mini 3", "Broadlink"),
-            (0x277c, "RM home", "Broadlink"),
-            (0x2783, "RM home", "Broadlink"),
-            (0x2787, "RM pro", "Broadlink"),
-            (0x278b, "RM plus", "Broadlink"),
-            (0x278f, "RM mini", "Broadlink"),
-            (0x2797, "RM pro+", "Broadlink"),
-            (0x279d, "RM pro+", "Broadlink"),
-            (0x27a1, "RM plus", "Broadlink"),
-            (0x27a6, "RM plus", "Broadlink"),
-            (0x27a9, "RM pro+", "Broadlink"),
-            (0x27c2, "RM mini 3", "Broadlink"),
-            (0x27d1, "RM mini 3", "Broadlink"),
-            (0x27de, "RM mini 3", "Broadlink"),
-        ],
-        rm4: [
-            (0x51da, "RM4 mini", "Broadlink"),
-            (0x5f36, "RM mini", "Broadlink"),
-            (0x6026, "RM4 pro", "Broadlink"),
-            (0x6070, "RM4C mini", "Broadlink"),
-            (0x610e, "RM4 mini", "Broadlink"),
-            (0x610f, "RM4C mini", "Broadlink"),
-            (0x61a2, "RM4 pro", "Broadlink"),
-            (0x62bc, "RM4 mini", "Broadlink"),
-            (0x62be, "RM4C mini", "Broadlink"),
-        ],
+        0x2711: (sp2, "SP2", "Broadlink"),
+        0x2719: (sp2, "SP2-compatible", "Honeywell"),
+        0x271a: (sp2, "SP2-compatible", "Honeywell"),
+        0x2720: (sp2, "SP mini", "Broadlink"),
+        0x2728: (sp2, "SP2-compatible", "URANT"),
+        0x2733: (sp2, "SP3", "Broadlink"),
+        0x2736: (sp2, "SP mini+", "Broadlink"),
+        0x273e: (sp2, "SP mini", "Broadlink"),
+        0x7530: (sp2, "SP2", "Broadlink (OEM)"),
+        0x753e: (sp2, "SP mini 3", "Broadlink"),
+        0x7546: (sp2, "SP2-UK/BR/IN", "Broadlink (OEM)"),
+        0x7918: (sp2, "SP2", "Broadlink (OEM)"),
+        0x7919: (sp2, "SP2-compatible", "Honeywell"),
+        0x791a: (sp2, "SP2-compatible", "Honeywell"),
+        0x7d00: (sp2, "SP3-EU", "Broadlink (OEM)"),
+        0x7d0d: (sp2, "SP mini 3", "Broadlink (OEM)"),
+        0x9479: (sp2, "SP3S-US", "Broadlink"),
+        0x947a: (sp2, "SP3S-EU", "Broadlink"),
 
-        # e-Sensor
-        a1: [(0x2714, "e-Sensor", "Broadlink")],
+        0x2712: (rm, "RM pro/pro+", "Broadlink"),
+        0x272a: (rm, "RM pro", "Broadlink"),
+        0x273d: (rm, "RM pro", "Broadlink"),
+        0x2737: (rm, "RM mini 3", "Broadlink"),
+        0x277c: (rm, "RM home", "Broadlink"),
+        0x2783: (rm, "RM home", "Broadlink"),
+        0x2787: (rm, "RM pro", "Broadlink"),
+        0x278b: (rm, "RM plus", "Broadlink"),
+        0x278f: (rm, "RM mini", "Broadlink"),
+        0x2797: (rm, "RM pro+", "Broadlink"),
+        0x279d: (rm, "RM pro+", "Broadlink"),
+        0x27a1: (rm, "RM plus", "Broadlink"),
+        0x27a6: (rm, "RM plus", "Broadlink"),
+        0x27a9: (rm, "RM pro+", "Broadlink"),
+        0x27c2: (rm, "RM mini 3", "Broadlink"),
+        0x27d1: (rm, "RM mini 3", "Broadlink"),
+        0x27de: (rm, "RM mini 3", "Broadlink"),
 
-        # Power Strip
-        mp1: [
-            (0x4eb5, "MP1-1K4S", "Broadlink"),
-            (0x4ef7, "MP1-1K4S", "Broadlink (OEM)"),
-        ],
+        0x51da: (rm4, "RM4 mini", "Broadlink"),
+        0x5f36: (rm4, "RM mini", "Broadlink"),
+        0x6026: (rm4, "RM4 pro", "Broadlink"),
+        0x6070: (rm4, "RM4C mini", "Broadlink"),
+        0x610e: (rm4, "RM4 mini", "Broadlink"),
+        0x610f: (rm4, "RM4C mini", "Broadlink"),
+        0x61a2: (rm4, "RM4 pro", "Broadlink"),
+        0x62bc: (rm4, "RM4 mini", "Broadlink"),
+        0x62be: (rm4, "RM4C mini", "Broadlink"),
 
-        # HVAC
-        hysen: [(0x4ead, "HY02B05H", "Hysen")],
+        0x2714: (a1, "e-Sensor", "Broadlink"),
 
-        # Wi-Fi Alarm Kit
-        S1C: [(0x2722, "S2KIT", "Broadlink")],
+        0x4eb5: (mp1, "MP1-1K4S", "Broadlink"),
+        0x4ef7: (mp1, "MP1-1K4S", "Broadlink (OEM)"),
 
-        # Electric Curtain Motor
-        dooya: [(0x4e4d, "DT360E-45/20", "Dooya")],
+        0x4ead: (hysen, "HY02B05H", "Hysen"),
 
-        # Wall Socket
-        bg1: [(0x51e3, "BG800/BG900", "BG Electrical")],
+        0x2722: (S1C, "S2KIT", "Broadlink"),
 
-        # Smart Bulb
-        lb1: [
-            (0x5043, "SB800TD", "Broadlink (OEM)"),
-            (0x60c8, "LB1", "Broadlink (OEM)"),
-        ],
+        0x4e4d: (dooya, "DT360E-45/20", "Dooya"),
+
+        0x51e3: (bg1, "BG800/BG900", "BG Electrical"),
+
+        0x5043: (lb1, "SB800TD", "Broadlink (OEM)"),
+        0x60c8: (lb1, "LB1", "Broadlink (OEM)"),
     }
 
     # Look for the class associated to devtype in devices
     try:
-        dev_class, model, manufacturer = next(
-            (dev_class, model, manufacturer)
-            for dev_class, dev_list in devices.items()
-            for dev_type, model, manufacturer in dev_list
-            if dev_type == devtype
-        )
-    except StopIteration:
+        dev_class, model, manufacturer = devices[devtype]
+    except KeyError:
         return device(host, mac, devtype, name=name, cloud=cloud)
 
     dev = dev_class(host, mac, devtype, name=name, cloud=cloud)


### PR DESCRIPTION
## The problem
I am working on an update for Home Assistant in which we need to register the device information, such as the model and manufacturer.

Currently this information is in the form of comments, inaccessible to the integrations, and some do not match the models and manufacturers presented in the official apps. So I decided to improve this.

## Proposed changes
I propose using the device types as keys to classes, models and manufacturers in the factory function (gendevice). Then we build the devices with this information and allow them to be accessed in Home Assistant and other integrations.

I made a dummy device generator and reverse engineered Broadlink app, IHC app and e-Control app to extract the correct models and manufacturers. They look good.

## Future reviews
This PR is the best I could do with the information I got. I resolved all possible conflicts by crossing information from the Broadlink app, IHC app, e-Control, GitHub and Google.

Even though I spent some time on this, there is still conflicting information that I was unable to resolve. If someone recognizes a device with the wrong model or manufacturer, please open an issue so I can fix it. Here is the checklist:
1. The model of your device is correct.
2. The manufacturer of your device is correct.
3. The OEM tag is correct.

