### PR TITLE
Add a method to lock/unlock the device

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -244,9 +244,21 @@ class device:
 
     def set_name(self, name):
         packet = bytearray(4)
-        packet.extend(map(ord, name))
+        packet += name.encode('utf-8')
+        packet += bytearray(0x50 - len(packet))
+        packet[0x43] = self.cloud
         response = self.send_packet(0x6a, packet)
         check_error(response[0x22:0x24])
+        self.name = name
+
+    def set_lock(self, state):
+        packet = bytearray(4)
+        packet += self.name.encode('utf-8')
+        packet += bytearray(0x50 - len(packet))
+        packet[0x43] = state
+        response = self.send_packet(0x6a, packet)
+        check_error(response[0x22:0x24])
+        self.cloud = bool(state)
 
     def get_type(self):
         return self.type


### PR DESCRIPTION
I figured out how to lock/unlock the discovery and authentication on these devices.

This method can disable the infamous "cloud byte", which has bothered many users since Broadlink app started locking devices automatically during setup.