### PR TITLE
Add support for SC1 device

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -31,6 +31,7 @@ def gendevice(devtype, host, mac, name=None, cloud=None):
         0x753e: (sp2, "SP mini 3", "Broadlink"),
         0X7544: (sp2, "SP2-CL", "Broadlink"),
         0x7546: (sp2, "SP2-UK/BR/IN", "Broadlink (OEM)"),
+        0x7547: (sp2, "SC1", "Broadlink"),
         0x7918: (sp2, "SP2", "Broadlink (OEM)"),
         0x7919: (sp2, "SP2-compatible", "Honeywell"),
         0x791a: (sp2, "SP2-compatible", "Honeywell"),


### PR DESCRIPTION
As reported [here](https://github.com/mjg59/python-broadlink/issues/142#issuecomment-364610667), the SC1 has the same firmware as SP2 and communicates in the same way. I checked.

This PR closes https://github.com/mjg59/python-broadlink/issues/142.