### PR TITLE
Fix timeout issue

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -112,7 +112,6 @@ def discover(timeout=None, local_ip_address=None, discover_ip_address='255.255.2
     cs.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
     cs.bind((local_ip_address, 0))
     port = cs.getsockname()[1]
-    starttime = time.time()
 
     devices = []
 
@@ -168,6 +167,7 @@ def discover(timeout=None, local_ip_address=None, discover_ip_address='255.255.2
         cs.close()
         return device
 
+    starttime = time.time()
     while (time.time() - starttime) < timeout:
         cs.settimeout(timeout - (time.time() - starttime))
         try:
@@ -338,8 +338,8 @@ class device:
         packet[0x20] = checksum & 0xff
         packet[0x21] = checksum >> 8
 
-        start_time = time.time()
         with self.lock:
+            start_time = time.time()
             cs = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
             cs.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 


### PR DESCRIPTION
## The problem
When a timeout error occurs, the error is propagated to all subsequent requests. This is happening because we are starting to count time outside the lock. The counter starts, but the socket is locked. When it gets unlocked, the timeout has already been reached.

## Proposed changes
I suggest we start counting inside the lock.

Fixes: https://github.com/home-assistant/core/issues/37000