### PR TITLE
Allow setting custom discover ip port

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -109,7 +109,12 @@ def gendevice(dev_type, host, mac, name=None, is_locked=None):
     )
 
 
-def discover(timeout=None, local_ip_address=None, discover_ip_address='255.255.255.255'):
+def discover(
+        timeout=None,
+        local_ip_address=None,
+        discover_ip_address='255.255.255.255',
+        discover_ip_port=80
+):
     if local_ip_address is None:
         with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
             s.connect(('8.8.8.8', 53))  # connecting to a UDP address doesn't send packets
@@ -156,7 +161,7 @@ def discover(timeout=None, local_ip_address=None, discover_ip_address='255.255.2
     packet[0x1c] = port & 0xff
     packet[0x1d] = port >> 8
     packet[0x26] = 6
-    
+
     checksum = 0xbeaf
     for b in packet:
         checksum = (checksum + b) & 0xffff
@@ -164,7 +169,7 @@ def discover(timeout=None, local_ip_address=None, discover_ip_address='255.255.2
     packet[0x20] = checksum & 0xff
     packet[0x21] = checksum >> 8
 
-    cs.sendto(packet, (discover_ip_address, 80))
+    cs.sendto(packet, (discover_ip_address, discover_ip_port))
     if timeout is None:
         response = cs.recvfrom(1024)
         responsepacket = bytearray(response[0])
@@ -285,7 +290,7 @@ class device:
         response = self.send_packet(0x6a, packet)
         check_error(response[0x22:0x24])
         payload = self.decrypt(response[0x38:])
-        return payload[0x4] | payload[0x5] << 8        
+        return payload[0x4] | payload[0x5] << 8
 
     def set_name(self, name):
         packet = bytearray(4)
@@ -446,7 +451,7 @@ class bg1(device):
 
     def get_state(self):
         """Get state of device.
-        
+
         Returns:
             dict: Dictionary of current state
             eg. `{"pwr":1,"pwr1":1,"pwr2":0,"maxworktime":60,"maxworktime1":60,"maxworktime2":0,"idcbrightness":50}`"""


### PR DESCRIPTION
Currently I am port forwarding to one of my Broadlink devices using a port that is different from port 80. Unfortunately the `broadlink.discover` method only allows for using port 80. To allow for a bit more flexibility I've added the `discover_ip_port` argument to the `broadlink.discover` method, which will default to 80 when it's not specified. 