### PR TITLE
Restore VPN support and create DNSLookupError exception

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -13,6 +13,7 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
 from .exceptions import check_error, exception
+from .helpers import get_local_ip
 
 
 def get_devices():
@@ -116,11 +117,7 @@ def discover(
         discover_ip_address='255.255.255.255',
         discover_ip_port=80
 ):
-    if local_ip_address is None:
-        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
-            s.connect(('8.8.8.8', 53))  # connecting to a UDP address doesn't send packets
-            local_ip_address = s.getsockname()[0]
-
+    local_ip_address = local_ip_address or get_local_ip()
     address = local_ip_address.split('.')
     cs = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     cs.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)

--- a/broadlink/exceptions.py
+++ b/broadlink/exceptions.py
@@ -13,23 +13,19 @@ class BroadlinkException(Exception):
             self.strerror = "%s: %s" % (args[1], args[2])
         elif len(args) == 2:
             self.errno = args[0]
-            self.strerror = args[1]
+            self.strerror = str(args[1])
         elif len(args) == 1:
             self.errno = None
-            self.strerror = args[0]
+            self.strerror = str(args[0])
         else:
             self.errno = None
-            self.strerror = None
+            self.strerror = ""
 
     def __str__(self):
         """Return the error message."""
         if self.errno is not None:
-            err_msg = "[Errno %s] %s" % (self.errno, self.strerror)
-        elif self.strerror is not None:
-            err_msg = "%s" % (self.strerror)
-        else:
-            err_msg = ""
-        return err_msg
+            return "[Errno %s] %s" % (self.errno, self.strerror)
+        return self.strerror
 
 
 class FirmwareException(BroadlinkException):
@@ -122,6 +118,12 @@ class LengthError(SDKException):
     pass
 
 
+class DNSError(SDKException):
+    """Domain name resolution error."""
+
+    pass
+
+
 class NetworkTimeoutError(SDKException):
     """Network timeout error."""
 
@@ -151,6 +153,7 @@ BROADLINK_EXCEPTIONS = {
     -4000: (NetworkTimeoutError, "Network timeout"),
     -4007: (LengthError, "Received data packet length error"),
     -4008: (ChecksumError, "Received data packet check error"),
+    -4013: (DNSError, "Domain name resolution error"),
 }
 
 

--- a/broadlink/exceptions.py
+++ b/broadlink/exceptions.py
@@ -118,8 +118,8 @@ class LengthError(SDKException):
     pass
 
 
-class DNSError(SDKException):
-    """Domain name resolution error."""
+class DNSLookupError(SDKException):
+    """Failed to obtain local IP address."""
 
     pass
 
@@ -153,7 +153,7 @@ BROADLINK_EXCEPTIONS = {
     -4000: (NetworkTimeoutError, "Network timeout"),
     -4007: (LengthError, "Received data packet length error"),
     -4008: (ChecksumError, "Received data packet check error"),
-    -4013: (DNSError, "Domain name resolution error"),
+    -4013: (DNSLookupError, "Failed to obtain local IP address"),
 }
 
 

--- a/broadlink/helpers.py
+++ b/broadlink/helpers.py
@@ -1,0 +1,18 @@
+"""Helper functions."""
+import socket
+
+
+def get_local_ip() -> str:
+    """Try to determine the local IP address of the machine."""
+    # Useful for VPNs.
+    try:
+        local_ip_address = socket.gethostbyname(socket.gethostname())
+        if not local_ip_address.startswith('127.'):
+            return local_ip_address
+    except OSError:
+        pass
+
+    # Connecting to UDP address does not send packets.
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+        s.connect(('8.8.8.8', 53))
+        return s.getsockname()[0]

--- a/broadlink/helpers.py
+++ b/broadlink/helpers.py
@@ -1,6 +1,8 @@
 """Helper functions."""
 import socket
 
+from .exceptions import exception
+
 
 def get_local_ip() -> str:
     """Try to determine the local IP address of the machine."""
@@ -9,8 +11,8 @@ def get_local_ip() -> str:
         local_ip_address = socket.gethostbyname(socket.gethostname())
         if not local_ip_address.startswith('127.'):
             return local_ip_address
-    except OSError:
-        pass
+    except socket.gaierror:
+        raise exception(-4013)  # DNS Error
 
     # Connecting to UDP address does not send packets.
     with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:


### PR DESCRIPTION
## The problem
When I [changed discover()](https://github.com/mjg59/python-broadlink/pull/378) to make it work with Home Assistant I removed `socket.gethostbyname(socket.gethostname())` lookup method because all of the reasons I mentioned and also because it was throwing an exception that was already in use. I thought it would be simpler to rollback to the old logic. But I didn't realize that many users may depend on this method for using discover() with VPNs. And now they need to discover the device to make it work with Home Assistant. So let me fix this quickly before people start getting mad :rofl:

## Proposed changes
This PR comes to restablish VPN support in discover() by using `socket.gethostbyname(socket.gethostname())`. If we get a socket.gaierror while trying to determine the local IP address we are gonna propagate it as DNS error so we can handle this exception in a non-ambiguous way and guide to user to the solution in Home Assistant.

This PR is another step towards exposing exceptions more clearly so that the applications that import this library can deal with errors correctly. This error may happen if the user is running Home Assistant in his own Docker environment and didn't add `--net=host` to runArgs in devcontainer.json. So we are gonna guide him to the solution. This happened to me and I had no idea, I ended up asking for help in Discord. So let's make this easier. These are the changes I propose:

- Create a DNSLookupError(SDKException) class for DNS errors.
- Create a separate file for helper functions in order to keep things organized (in a future PR I will clean up and move crc16 and random stuff to this file).
- Create a helper function to get the local IP address.

The logic is similar to what we had before, but now we are raising a DNSLookupError() so we can deal with the exception in Home Assistant. Why not just let the exception blow an OSError()? Because it conflicts with errors related to `socket.sendto` and the destination IP, which we are already treating as OSError() there.

## Example
### Before
- No VPN support.
- Ambiguous exceptions.

```python3
>>> d = blk.discover(local_ip_address='test', timeout=3)
Traceback (most recent call last):
  File "<pyshell#10>", line 1, in <module>
    d = blk.discover(local_ip_address='test', timeout=3)
  File "/home/felipe/.local/lib/python3.6/site-packages/broadlink/__init__.py", line 114, in discover
    cs.bind((local_ip_address, 0))
socket.gaierror: [Errno -2] Name or service not known

>>> d = blk.discover(discover_ip_address='test', timeout=3)
Traceback (most recent call last):
  File "<pyshell#8>", line 1, in <module>
    d = blk.discover(discover_ip_address='test', timeout=3)
  File "/home/felipe/.local/lib/python3.6/site-packages/broadlink/__init__.py", line 159, in discover
    cs.sendto(packet, (discover_ip_address, 80))
socket.gaierror: [Errno -2] Name or service not known
```

### After
- Restore VPN support.
- Raise DNSLookupError() for local address lookup error
```python3
>>> d = blk.discover(local_ip_address='test', timeout=3)
Traceback (most recent call last):
  File "<pyshell#10>", line 1, in <module>
    d = blk.discover(local_ip_address='test', timeout=3)
  File "/home/felipe/.local/lib/python3.6/site-packages/broadlink/__init__.py", line 114, in discover
    cs.bind((local_ip_address, 0))
broadlink.exceptions.DNSLookupError: [Errno -4013] Failed to obtain local IP address

>>> d = blk.discover(discover_ip_address='test', timeout=3)
Traceback (most recent call last):
  File "<pyshell#8>", line 1, in <module>
    d = blk.discover(discover_ip_address='test', timeout=3)
  File "/home/felipe/.local/lib/python3.6/site-packages/broadlink/__init__.py", line 159, in discover
    cs.sendto(packet, (discover_ip_address, 80))
socket.gaierror: [Errno -2] Name or service not known
```