### PR TITLE
Add support for Broadlink MP1-1K3S2U (0x4f1b)

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -74,6 +74,7 @@ def get_devices():
 
         0x4eb5: (mp1, "MP1-1K4S", "Broadlink"),
         0x4ef7: (mp1, "MP1-1K4S", "Broadlink (OEM)"),
+        0x4f1b: (mp1, "MP1-1K3S2U", "Broadlink (OEM)"),
         0x4f65: (mp1, "MP1-1K3S2U", "Broadlink"),
 
         0x5043: (lb1, "SB800TD", "Broadlink (OEM)"),


### PR DESCRIPTION
We found a [new MP1 type](https://github.com/home-assistant/core/issues/40077#issuecomment-694438094). It works  like the others.