### PR TITLE
Add support for Broadlink MP2 (0x7540)

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -30,6 +30,7 @@ def get_devices():
         0x273e: (sp2, "SP mini", "Broadlink"),
         0x7530: (sp2, "SP2", "Broadlink (OEM)"),
         0x753e: (sp2, "SP mini 3", "Broadlink"),
+        0x7540: (sp2, "MP2", "Broadlink"),
         0X7544: (sp2, "SP2-CL", "Broadlink"),
         0x7546: (sp2, "SP2-UK/BR/IN", "Broadlink (OEM)"),
         0x7547: (sp2, "SC1", "Broadlink"),


### PR DESCRIPTION
The [MP2](https://github.com/home-assistant/core/pull/36914#issuecomment-694520428) is a smart power strip. It does not support individual control. We can use the SP2 class for now.