### PR TITLE
Add support for Broadlink RM pro+ (0x27c3)

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -56,6 +56,7 @@ def get_devices():
         0x27a6: (rm, "RM plus", "Broadlink"),
         0x27a9: (rm, "RM pro+", "Broadlink"),
         0x27c2: (rm, "RM mini 3", "Broadlink"),
+        0x27c3: (rm, "RM pro+", "Broadlink"),
         0x27d1: (rm, "RM mini 3", "Broadlink"),
         0x27de: (rm, "RM mini 3", "Broadlink"),
 


### PR DESCRIPTION
We found another device type. This is a [RM pro+](https://github.com/home-assistant/core/issues/40191#issuecomment-694671156)  (0x27c3).
