### PR TITLE
Add support for Ankuoo NEO (0x2717) and NEO PRO (0x2716)

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -21,6 +21,8 @@ def get_devices():
         0x0000: (sp1, "SP1", "Broadlink"),
 
         0x2711: (sp2, "SP2", "Broadlink"),
+        0x2716: (sp2, "NEO PRO", "Ankuoo"),
+        0x2717: (sp2, "NEO", "Ankuoo"),
         0x2719: (sp2, "SP2-compatible", "Honeywell"),
         0x271a: (sp2, "SP2-compatible", "Honeywell"),
         0x2720: (sp2, "SP mini", "Broadlink"),


### PR DESCRIPTION
## Proposed changes
Add support for Ankuoo NEO and Ankuoo NEO PRO: https://github.com/home-assistant/core/issues/40191#issuecomment-695026275

- Ankuoo NEO PRO (0x2716): smart Wi-Fi switch with Broadlink DNA and power meter (w).
- Ankuoo NEO (0x2717): smart Wi-Fi switch with Broadlink DNA and no power meter.

They work with the SP2 class.
