### PR TITLE
Add support for Broadlink RM mini 3 (0x27d0 and 0x27cd)

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -56,6 +56,7 @@ def get_devices():
         0x27a6: (rm, "RM plus", "Broadlink"),
         0x27a9: (rm, "RM pro+", "Broadlink"),
         0x27c2: (rm, "RM mini 3", "Broadlink"),
+        0x27d0, (rm, "RM mini 3", "Broadlink"),
         0x27d1: (rm, "RM mini 3", "Broadlink"),
         0x27de: (rm, "RM mini 3", "Broadlink"),
 

--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -56,7 +56,8 @@ def get_devices():
         0x27a6: (rm, "RM plus", "Broadlink"),
         0x27a9: (rm, "RM pro+", "Broadlink"),
         0x27c2: (rm, "RM mini 3", "Broadlink"),
-        0x27d0, (rm, "RM mini 3", "Broadlink"),
+        0x27cd: (rm, "RM mini 3", "Broadlink"),
+        0x27d0: (rm, "RM mini 3", "Broadlink"),
         0x27d1: (rm, "RM mini 3", "Broadlink"),
         0x27de: (rm, "RM mini 3", "Broadlink"),
 


### PR DESCRIPTION
## Proposed changes
Add support for RM Mini 3 [0x27d0](https://github.com/home-assistant/core/issues/40286#issuecomment-695218633) and [0x27cd](https://github.com/home-assistant/core/issues/40191#issuecomment-695319237).