### PR TITLE
Add support for OEM Broadlink SP2-IL (0x7539)

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -29,6 +29,7 @@ def get_devices():
         0x2736: (sp2, "SP mini+", "Broadlink"),
         0x273e: (sp2, "SP mini", "Broadlink"),
         0x7530: (sp2, "SP2", "Broadlink (OEM)"),
+        0x7539: (sp2, "SP2-IL", "Broadlink (OEM)"),
         0x753e: (sp2, "SP mini 3", "Broadlink"),
         0X7544: (sp2, "SP2-CL", "Broadlink"),
         0x7546: (sp2, "SP2-UK/BR/IN", "Broadlink (OEM)"),


### PR DESCRIPTION
We found another [OEM Broadlink SP2](https://github.com/home-assistant/core/issues/40287#issuecomment-695195548) device. This SP2 is retailed in Israel under the brand name "Smart Grade". Here is a [picture](https://smartgrade.co.il/product/%D7%9E%D7%AA%D7%90%D7%9D-%D7%97%D7%9B%D7%9D-%D7%9C%D7%A9%D7%A7%D7%A2-%D7%99%D7%A9%D7%A8%D7%90%D7%9C%D7%99/).

- Does not have power meter.
- Does not have night light.
- Does not have an official name in the Broadlink apps, so I chose SP2-IL (IL = Israel plug type).