### PR TITLE
Add support for Broadlink SP mini 3 (0x7d11)

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -41,6 +41,7 @@ SUPPORTED_TYPES = {
     0x9479: (sp2, "SP3S-US", "Broadlink"),
     0x947a: (sp2, "SP3S-EU", "Broadlink"),
     0x7579: (sp4, "SP4L-EU", "Broadlink"),
+    0x7d11: (sp4, "SP mini 3", "Broadlink (OEM)"),
     0x2712: (rm, "RM pro/pro+", "Broadlink"),
     0x272a: (rm, "RM pro", "Broadlink"),
     0x2737: (rm, "RM mini 3", "Broadlink"),


### PR DESCRIPTION
We can control this device with the SP4 class.
https://github.com/home-assistant/core/issues/36624#issuecomment-704425663