### PR TITLE
Add support for Broadlink RM4 mini (0x653a)

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -73,6 +73,7 @@ SUPPORTED_TYPES = {
     0x62be: (rm4, "RM4C mini", "Broadlink"),
     0x648d: (rm4, "RM4 mini", "Broadlink"),
     0x649b: (rm4, "RM4 pro", "Broadlink"),
+    0x653a: (rm4, "RM4 mini", "Broadlink"),
     0x2714: (a1, "e-Sensor", "Broadlink"),
     0x4eb5: (mp1, "MP1-1K4S", "Broadlink"),
     0x4ef7: (mp1, "MP1-1K4S", "Broadlink (OEM)"),


### PR DESCRIPTION
https://github.com/home-assistant/core/issues/41633