### PR TITLE
Update packet count in the authentication step

### DIFF
--- a/broadlink/device.py
+++ b/broadlink/device.py
@@ -195,6 +195,7 @@ class device:
         if len(key) % 16 != 0:
             return False
 
+        self.count = int.from_bytes(response[0x28:0x30], "little")
         self.id = payload[0x03::-1]
         self.update_aes(key)
         return True


### PR DESCRIPTION
## Context
The counter comes in bytes 0x28 and 0x29 and is used to identify the packet. If the device receives a packet with the same counter, the command is not executed twice. This can be reproduced with the following code:
```python3
d = blk.hello("192.168.0.12")  # Example device
d.auth()
d.send_data(b64decode("sv8kAAUGEwYGDAsGBgYGBgUMCwsLBgUGBgYGBgYGBgsLCwYGCwYGDAAAAAA=="))

# Same counter, this command won't be executed.
d.count -= 1
d.send_data(b64decode("sv8kAAUGEwYGDAsGBgYGBgUMCwsLBgUGBgYGBgYGBgsLCwYGCwYGDAAAAAA=="))
```
This is the expected behavior. We are already using this. When the timeout is reached, we send the packet again with the same counter without worrying about commands being executed twice.

## The problem
When we re-instantiate the controller or restart the application, the counter is lost. So if we try something like this:
```python3
d = blk.hello("192.168.0.12")  # Example device
d.auth()
d.send_data(b64decode("sv8kAAUGEwYGDAsGBgYGBgUMCwsLBgUGBgYGBgYGBgsLCwYGCwYGDAAAAAA=="))

# Same device, but we've lost the counter
d = blk.hello("192.168.0.12")
d.auth()
d.send_data(b64decode("sv8kAAUGEwYGDAsGBgYGBgUMCwsLBgUGBgYGBgYGBgsLCwYGCwYGDAAAAAA=="))
```
The device gets crazy because the counter is wrong and it stops eliminating duplicate packets. So if we send the same packet twice, even with the same counter, the device executes two different commands.

The code we are sending is an easy way to reproduce the issue. It is a blocking RF code with 255 repetitions. The timeout is reached 3 times, 3 packets are sent and 3 different commands are executed. This wouldn't happen if the counter was persistent, so...

## The solution
I propose to update the counter when we authenticate to the device, so this information will always be up to date, even if we restart the application.

Fixes https://github.com/home-assistant/core/issues/41957
Fixes https://github.com/home-assistant/core/issues/37000