### PR TITLE
Add a function to send ping packets

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -6,7 +6,7 @@ from typing import Generator, List, Union, Tuple
 from .alarm import S1C
 from .climate import hysen
 from .cover import dooya
-from .device import device, scan
+from .device import device, ping, scan
 from .exceptions import exception
 from .light import lb1
 from .remote import rm, rm4

--- a/broadlink/device.py
+++ b/broadlink/device.py
@@ -98,6 +98,20 @@ def scan(
         conn.close()
 
 
+def ping(host: str, port: int = 80) -> None:
+    """Send a ping packet to a host or broadcast address.
+
+    This packet feeds the watchdog timer of firmwares >= v53.
+    Useful to prevent reboots when the cloud cannot be reached.
+    It must be sent every 2 minutes in such cases.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as conn:
+        conn.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+        packet = bytearray(0x30)
+        packet[0x26] = 1
+        conn.sendto(packet, (host, port))
+
+
 class device:
     """Controls a Broadlink device."""
 
@@ -229,6 +243,15 @@ class device:
         self.name = name
         self.is_locked = is_locked
         return True
+
+    def ping(self) -> None:
+        """Ping the device.
+
+        This packet feeds the watchdog timer of firmwares >= v53.
+        Useful to prevent reboots when the cloud cannot be reached.
+        It must be sent every 2 minutes in such cases.
+        """
+        ping(self.host[0], port=self.host[1])
 
     def get_fwversion(self) -> int:
         """Get firmware version."""


### PR DESCRIPTION
Some Broadlink firmwares have a watchdog timer to ensure that the device remains connected to the cloud. The devices reboot when they don't receive heartbeat messages from the cloud for more than 3 minutes.

Lots of users want to block access to the internet for privacy reasons and this is causing their devices to reboot periodically. This PR comes to add a function to send heartbeat messages and keep the devices awake even without access to the cloud.

Credits to @marcan, who found the watchdog packet.

Fixes: https://github.com/mjg59/python-broadlink/issues/458