### PR TITLE
Timeout improvements

### DIFF
--- a/broadlink/device.py
+++ b/broadlink/device.py
@@ -308,11 +308,11 @@ class device:
         packet[0x20] = checksum & 0xFF
         packet[0x21] = checksum >> 8
 
-        start_time = time.time()
-        timeout = self.timeout
-
         with self.lock:
             with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as conn:
+                timeout = self.timeout
+                start_time = time.time()
+
                 while True:
                     time_left = timeout - (time.time() - start_time)
                     conn.settimeout(min(5, time_left))

--- a/broadlink/device.py
+++ b/broadlink/device.py
@@ -309,20 +309,16 @@ class device:
 
         start_time = time.time()
         with self.lock:
-            conn = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-            conn.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-
-            while True:
-                try:
-                    conn.sendto(packet, self.host)
-                    conn.settimeout(1)
-                    resp, _ = conn.recvfrom(2048)
-                    break
-                except socket.timeout:
-                    if (time.time() - start_time) > self.timeout:
-                        conn.close()
-                        raise exception(-4000)  # Network timeout.
-            conn.close()
+            with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as conn:
+                while True:
+                    try:
+                        conn.sendto(packet, self.host)
+                        conn.settimeout(1)
+                        resp, _ = conn.recvfrom(2048)
+                        break
+                    except socket.timeout:
+                        if (time.time() - start_time) > self.timeout:
+                            raise exception(-4000)  # Network timeout.
 
         if len(resp) < 0x30:
             raise exception(-4007)  # Length error.

--- a/broadlink/device.py
+++ b/broadlink/device.py
@@ -262,7 +262,7 @@ class device:
         """Return device type."""
         return self.type
 
-    def send_packet(self, command: int, payload: bytes) -> bytes:
+    def send_packet(self, command: int, payload: bytes, retry_intvl: float = 1.0) -> bytes:
         """Send a packet to the device."""
         self.count = ((self.count + 1) | 0x8000) & 0xFFFF
         packet = bytearray(0x38)
@@ -315,11 +315,11 @@ class device:
 
                 while True:
                     time_left = timeout - (time.time() - start_time)
-                    conn.settimeout(min(5, time_left))
+                    conn.settimeout(min(retry_intvl, time_left))
                     conn.sendto(packet, self.host)
 
                     try:
-                        resp, _ = conn.recvfrom(2048)
+                        resp = conn.recvfrom(2048)[0]
                         break
                     except socket.timeout:
                         if (time.time() - start_time) > timeout:

--- a/broadlink/remote.py
+++ b/broadlink/remote.py
@@ -13,10 +13,10 @@ class rm(device):
         device.__init__(self, *args, **kwargs)
         self.type = "RM2"
 
-    def _send(self, command: int, data: bytes = b'') -> bytes:
+    def _send(self, command: int, data: bytes = b'', retry_intvl: float = 1.0) -> bytes:
         """Send a packet to the device."""
         packet = struct.pack("<I", command) + data
-        resp = self.send_packet(0x6A, packet)
+        resp = self.send_packet(0x6A, packet, retry_intvl=retry_intvl)
         check_error(resp[0x22:0x24])
         payload = self.decrypt(resp[0x38:])
         return payload[0x4:]
@@ -27,7 +27,7 @@ class rm(device):
 
     def send_data(self, data: bytes) -> None:
         """Send a code to the device."""
-        self._send(0x2, data)
+        self._send(0x2, data=data, retry_intvl=5)
 
     def enter_learning(self) -> None:
         """Enter infrared learning mode."""
@@ -71,10 +71,10 @@ class rm4(rm):
         device.__init__(self, *args, **kwargs)
         self.type = "RM4"
 
-    def _send(self, command: int, data: bytes = b'') -> bytes:
+    def _send(self, command: int, data: bytes = b'', retry_intvl: float = 1.0) -> bytes:
         """Send a packet to the device."""
         packet = struct.pack("<HI", len(data) + 4, command) + data
-        resp = self.send_packet(0x6A, packet)
+        resp = self.send_packet(0x6A, packet, retry_intvl=retry_intvl)
         check_error(resp[0x22:0x24])
         payload = self.decrypt(resp[0x38:])
         p_len = struct.unpack("<H", payload[:0x2])[0]


### PR DESCRIPTION
## Problem 1: False-positive NetworkTimeout() exception
Some operations are blocking. When we send a long RF code, the device takes a long time to respond, but it doesn't mean the connection timed out.

Let's take this code for example:
```
b64:JgD/AgABKJIUERQ3FBEUERQRFBEUERQ3FDcUERQ3FDcUERQ3FDcUERQ3FBEUNxQ3FDcUNxQRFBEUERQ3FBEUERQRFBEUNxQ3EwAfBQABKZMUERQ2FBEVEhISExIUERQ2FDcTEhM3FDYUERQ3EzcUERQRFDYUERU2FDYUNhQRFREUNhMSFDYVEBQSExITNxM3FQAFQQABKEkUAAxeAAEoShMADF8AAShJFQAMXQABKUkUAAxeAAEpSRUADF0AASlJFAAMXgABKEkUAAxeAAEoShMADF4AASlJFQAMXAABKUkTAAxeAAEpSRMADF4AAShKFAAMXQABKUkUAAxdAAEoShQADF0AAShJFAAMXgABKEkUAAxdAAEpSRQADF0AASlJFAAMXQABKUkTAAxeAAEoSRQADF4AAShJFAAMXgABKEkUAAxeAAEoSRUADF0AAShJFAAMXgABKEkUAAxdAAEpSRQADF0AAShJFAAMXQABKEoTAB8FAAEokxQSEzcTEhQRFBEUEhMSEzcUNhQRFDcTNxMSFTUUNhQSEzcUNhUQFDcTNxQ2FRAUEhMSExIUNhQRFRETEhM3FDYUAAVCAAEpSRMAHwUAASiTFBITNxMSFBEUERQSExITNxQ2FBEUNxM3ExIVNRQ2FBITNxQ2FRAUNxM3FDYVEBQSExITEhQ2FBEVERMSEzcUNhQABUIAASlJEwANBQ==
```
It takes 4.5s until we get a response from the device. [This](https://github.com/mjg59/python-broadlink/pull/486) will prevent the device from sending the code repeatedly when the timeout blows in the inner loop, but even with that fix we need to increase the timeout to avoid throwing a false-positive NetworkTimeout() in the end.

## Problem 2: Multi-threads, lock and timeout
When we call device.send_data() (operation A) from thread A and then call device.send_data() (operation B) from thread B before the operation A is finished, we're going to wait for operation A to finish [here](https://github.com/mjg59/python-broadlink/blob/29345a129ff6c98962fccba8ada1ea049fd9ec16/broadlink/device.py#L311-L312). But we are starting to count operation B outside the lock, so we can timeout operation B even before it is started. My suggestion is to only start counting inside the lock.

## Proposed changes
- Use a context manager to deal with conn.close() in device.send_packet().
- Remove the SO_REUSEADDR option because we don't need to reuse the port. The OS will bind() to any available port.
- Create a retry_intvl parameter in device.send_packet() to expose the interval, in seconds, between retries.
- Increase the retry_intvl in rm and rm4.send_data() from 1 to 5 to avoid running out of time on blocking operations like sending long RF codes.
- Start the timer inside the lock to avoid running out of time on blocking operations.