### PR TITLE
feat: add SP4M plug support

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -41,6 +41,7 @@ SUPPORTED_TYPES = {
     0x9479: (sp2, "SP3S-US", "Broadlink"),
     0x947a: (sp2, "SP3S-EU", "Broadlink"),
     0x648b: (sp4m, "SP4M-US", "Broadlink"),
+    0x756c: (sp4l, "SP4M", "Broadlink"),
     0x7579: (sp4l, "SP4L-EU", "Broadlink"),
     0x7583: (sp4l, "SP mini 3", "Broadlink"),
     0x7d11: (sp4l, "SP mini 3", "Broadlink"),


### PR DESCRIPTION
This is a retail version in mainland China.
Product page: https://item.jd.com/66791859907.html

As the page states, it's "SP4M".
So I tried `sp4m` at first. Not work.
Instead, the `sp4l` class worked.

I wonder if it is necessary to rename the `sp4m` class. "SP4M" uses `sp4l`, is a bit weird.