### PR TITLE
Overload __str__ in the device class

### DIFF
--- a/broadlink/device.py
+++ b/broadlink/device.py
@@ -143,6 +143,13 @@ class device:
             "Locked" if self.is_locked else "Unlocked",
         )
 
+    def __str__(self):
+        return "%s (%s at %s)" % (
+            self.name,
+            self.model or hex(self.devtype),
+            self.host[0],
+        )
+
     def update_aes(self, key: bytes) -> None:
         """Update AES."""
         self.aes = Cipher(


### PR DESCRIPTION
## Proposed change
Add a __str__ representation to the device class to assist with error messages. The device will appear in the logs as follows:

`Living Room (RM mini 3 at 192.168.0.21)`
