### PR TITLE
Rename SP4L to SP4 and SP4M to SP4B

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -11,7 +11,7 @@ from .exceptions import exception
 from .light import lb1
 from .remote import rm, rm4
 from .sensor import a1
-from .switch import bg1, mp1, sp1, sp2, sp4l, sp4m
+from .switch import bg1, mp1, sp1, sp2, sp4, sp4b
 
 
 SUPPORTED_TYPES = {
@@ -40,10 +40,11 @@ SUPPORTED_TYPES = {
     0x7d0d: (sp2, "SP mini 3", "Broadlink (OEM)"),
     0x9479: (sp2, "SP3S-US", "Broadlink"),
     0x947a: (sp2, "SP3S-EU", "Broadlink"),
-    0x648b: (sp4m, "SP4M-US", "Broadlink"),
-    0x7579: (sp4l, "SP4L-EU", "Broadlink"),
-    0x7583: (sp4l, "SP mini 3", "Broadlink"),
-    0x7d11: (sp4l, "SP mini 3", "Broadlink"),
+    0x756c: (sp4, "SP4M", "Broadlink"),
+    0x7579: (sp4, "SP4L-EU", "Broadlink"),
+    0x7583: (sp4, "SP mini 3", "Broadlink"),
+    0x7d11: (sp4, "SP mini 3", "Broadlink"),
+    0x648b: (sp4b, "SP4M-US", "Broadlink"),
     0x2712: (rm, "RM pro/pro+", "Broadlink"),
     0x272a: (rm, "RM pro", "Broadlink"),
     0x2737: (rm, "RM mini 3", "Broadlink"),

--- a/broadlink/switch.py
+++ b/broadlink/switch.py
@@ -219,13 +219,13 @@ class sp2(device):
         return int(hex(payload[0x07] * 256 + payload[0x06])[2:]) + int(hex(payload[0x05])[2:]) / 100.0
 
 
-class sp4l(device):
-    """Controls a Broadlink SP4L."""  
+class sp4(device):
+    """Controls a Broadlink SP4."""  
 
     def __init__(self, *args, **kwargs) -> None:
         """Initialize the controller."""
         device.__init__(self, *args, **kwargs)
-        self.type = "SP4L"
+        self.type = "SP4"
 
     def set_power(self, state: bool) -> None:
         """Set the power state of the device."""
@@ -301,13 +301,13 @@ class sp4l(device):
         return state
 
 
-class sp4m(sp4l):
-    """Controls a Broadlink SP4M."""
+class sp4b(sp4):
+    """Controls a Broadlink SP4 (type B)."""
 
     def __init__(self, *args, **kwargs) -> None:
         """Initialize the controller."""
         device.__init__(self, *args, **kwargs)
-        self.type = "SP4M"
+        self.type = "SP4B"
 
     def _encode(self, flag: int, state: dict) -> bytes:
         """Encode a message."""


### PR DESCRIPTION
We didn't have [this information](https://github.com/mjg59/python-broadlink/pull/466#issue-513394658) when I picked a name for these classes. I think we should rename them before the release.

I suggest renaming:
- sp4l to sp4, because it is the parent class and has more devices;
- sp4m to sp4b, because it inherits from sp4, but requires the payload to be preceded by its length (unsigned short / little endian).