### PR TITLE
Add support for Broadlink RM4 pro (0x653C)

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -79,6 +79,7 @@ SUPPORTED_TYPES = {
     0x648D: (rm4, "RM4 mini", "Broadlink"),
     0x649B: (rm4, "RM4 pro", "Broadlink"),
     0x653A: (rm4, "RM4 mini", "Broadlink"),
+    0x653C: (rm4, "RM4 pro", "Broadlink"),
     0x2714: (a1, "e-Sensor", "Broadlink"),
     0x4EB5: (mp1, "MP1-1K4S", "Broadlink"),
     0x4EF7: (mp1, "MP1-1K4S", "Broadlink (OEM)"),


### PR DESCRIPTION
Add support for Broadlink RM4 pro (0x653C)
https://github.com/home-assistant/core/issues/42983