### PR TITLE
Add support for Broadlink RM4C mini (0x6539)

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -78,6 +78,7 @@ SUPPORTED_TYPES = {
     0x62BE: (rm4, "RM4C mini", "Broadlink"),
     0x648D: (rm4, "RM4 mini", "Broadlink"),
     0x649B: (rm4, "RM4 pro", "Broadlink"),
+    0x6539: (rm4, "RM4C mini", "Broadlink"),
     0x653A: (rm4, "RM4 mini", "Broadlink"),
     0x2714: (a1, "e-Sensor", "Broadlink"),
     0x4EB5: (mp1, "MP1-1K4S", "Broadlink"),


### PR DESCRIPTION
Add support for Broadlink RM4C mini (0x6539)
https://github.com/mjg59/python-broadlink/pull/411#issuecomment-728289482
https://github.com/home-assistant/core/issues/42983#issuecomment-729802091