### PR TITLE
Add support for Broadlink MCB1 (0x756F and 0xA56A)

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -41,6 +41,7 @@ SUPPORTED_TYPES = {
     0x9479: (sp2, "SP3S-US", "Broadlink"),
     0x947A: (sp2, "SP3S-EU", "Broadlink"),
     0x756C: (sp4, "SP4M", "Broadlink"),
+    0x756F: (sp4, "MCB1", "Broadlink"),
     0x7579: (sp4, "SP4L-EU", "Broadlink"),
     0x7583: (sp4, "SP mini 3", "Broadlink"),
     0x7D11: (sp4, "SP mini 3", "Broadlink"),

--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -45,6 +45,7 @@ SUPPORTED_TYPES = {
     0x7579: (sp4, "SP4L-EU", "Broadlink"),
     0x7583: (sp4, "SP mini 3", "Broadlink"),
     0x7D11: (sp4, "SP mini 3", "Broadlink"),
+    0xA56A: (sp4, "MCB1", "Broadlink"),
     0x648B: (sp4b, "SP4M-US", "Broadlink"),
     0x2712: (rm, "RM pro/pro+", "Broadlink"),
     0x272A: (rm, "RM pro", "Broadlink"),


### PR DESCRIPTION
The [MCB1 control box](http://www.mybestcon.com/mcb1.html) can be controlled with the SP4 class.

```python3
>>> d.get_state()
{'pwr': 0, 'indicator': 1, 'maxworktime': 0, 'childlock': 0}
```

0x756F: https://github.com/mjg59/python-broadlink/issues/393#issuecomment-731763934
0xA56A: https://github.com/mjg59/python-broadlink/issues/393#issuecomment-737799174