### PR TITLE
Add support for Broadlink RM mini 3 (0x6508)

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -81,6 +81,7 @@ SUPPORTED_TYPES = {
     0x6364: (rm4, "RM4S", "Broadlink"),
     0x648D: (rm4, "RM4 mini", "Broadlink"),
     0x649B: (rm4, "RM4 pro", "Broadlink"),
+    0x6508: (rm4, "RM mini 3", "Broadlink"),
     0x6539: (rm4, "RM4C mini", "Broadlink"),
     0x653A: (rm4, "RM4 mini", "Broadlink"),
     0x653C: (rm4, "RM4 pro", "Broadlink"),


### PR DESCRIPTION
The RM mini 3 (0x6508) is [green](https://pt.aliexpress.com/item/1005001494476013.html) and can be controlled with the RM4 class.
From: https://github.com/home-assistant/core/issues/43567.