### PR TITLE
Add support for Efergy Ego (0x271D)

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -21,6 +21,7 @@ SUPPORTED_TYPES = {
     0x2717: (sp2, "NEO", "Ankuoo"),
     0x2719: (sp2, "SP2-compatible", "Honeywell"),
     0x271A: (sp2, "SP2-compatible", "Honeywell"),
+    0x271D: (sp2, "Ego", "Efergy"),
     0x2720: (sp2, "SP mini", "Broadlink"),
     0x2728: (sp2, "SP2-compatible", "URANT"),
     0x2733: (sp2, "SP3", "Broadlink"),


### PR DESCRIPTION
Add support for [Efergy Ego](https://in.rsdelivers.com/product/efergy/ego-uk/efergy-ego-smart-wi-fi-socket/8997804) (0x271D).

From:
https://github.com/home-assistant/core/issues/40191#issuecomment-733490632
https://github.com/mjg59/python-broadlink/issues/200#issue-345371869