### PR TITLE
Clamp the packet count between 0x8000 and 0xFFFF to eliminate duplicate packets

### DIFF
--- a/broadlink/device.py
+++ b/broadlink/device.py
@@ -120,7 +120,7 @@ class device:
         self.model = model
         self.manufacturer = manufacturer
         self.is_locked = is_locked
-        self.count = random.randrange(0xFFFF)
+        self.count = random.randint(0x8000, 0xFFFF)
         self.iv = bytes.fromhex("562e17996d093d28ddb3ba695a2e6f58")
         self.id = bytes(4)
         self.type = "Unknown"
@@ -202,7 +202,6 @@ class device:
         if len(key) % 16 != 0:
             return False
 
-        self.count = int.from_bytes(response[0x28:0x30], "little")
         self.id = payload[0x03::-1]
         self.update_aes(key)
         return True
@@ -264,7 +263,7 @@ class device:
 
     def send_packet(self, command: int, payload: bytes) -> bytes:
         """Send a packet to the device."""
-        self.count = (self.count + 1) & 0xFFFF
+        self.count = ((self.count + 1) | 0x8000) & 0xFFFF
         packet = bytearray(0x38)
         packet[0x00] = 0x5A
         packet[0x01] = 0xA5


### PR DESCRIPTION
We still have this [problem](https://github.com/mjg59/python-broadlink/pull/454/files). I made a mistake there, the solution doesn't work because when we send the authentication packet the device returns the packet count we sent (and not the previous count, in which we are interested).

The goal here is to start over based on a [discovery](https://github.com/mjg59/python-broadlink/pull/454#issuecomment-735409117) made by @hogi1200. When we send a packet count between 0x8000 and 0xFFFF the device doesn't have problems to eliminate duplicate packets, so this is definitely the way to go.


