### PR TITLE
Add support for Broadlink SCB1E (0x6113)

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -47,6 +47,7 @@ SUPPORTED_TYPES = {
     0x7583: (sp4, "SP mini 3", "Broadlink"),
     0x7D11: (sp4, "SP mini 3", "Broadlink"),
     0xA56A: (sp4, "MCB1", "Broadlink"),
+    0x6113: (sp4b, "SCB1E", "Broadlink"),
     0x648B: (sp4b, "SP4M-US", "Broadlink"),
     0x2712: (rm, "RM pro/pro+", "Broadlink"),
     0x272A: (rm, "RM pro", "Broadlink"),


### PR DESCRIPTION
SCB1E is a control box with power meter that can be controlled with the SP4B class.

```python3
>>> d.get_state()
{'pwr': 1, 'indicator': 1, 'maxworktime': 0, 'current': 8169, 'volt': 234600, 'power': 1916480, 'totalconsum': 10, 'overload': 0, 'childlock': 0}
```

From: https://github.com/mjg59/python-broadlink/issues/393#issuecomment-737799174.