### PR TITLE
Add support for Broadlink SP4L-EU (0x618B)

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -48,6 +48,7 @@ SUPPORTED_TYPES = {
     0x7D11: (sp4, "SP mini 3", "Broadlink"),
     0xA56A: (sp4, "MCB1", "Broadlink"),
     0x6113: (sp4b, "SCB1E", "Broadlink"),
+    0x618B: (sp4b, "SP4L-EU", "Broadlink"),
     0x648B: (sp4b, "SP4M-US", "Broadlink"),
     0x2712: (rm, "RM pro/pro+", "Broadlink"),
     0x272A: (rm, "RM pro", "Broadlink"),


### PR DESCRIPTION
The SP4L-EU (0x618B) can be controlled with the SP4B class.

```python3
>>> d.get_state()
{'pwr': 1, 'ntlight': 0, 'indicator': 1, 'usbpwr': 0, 'maxworktime': 0, 'usbmaxworktime': 0, 'ntlbrightness': 100, 'current': -1, 'volt': -1, 'power': -1, 'totalconsum': -1, 'overload': -1, 'childlock': 0}
```

From: https://github.com/mjg59/python-broadlink/issues/393#issuecomment-738692392

Credits to @Mister-Slowhand who helped with tests and captures to add this and many other types. Thank you very much!