### PR TITLE
Add support for Broadlink SP4L-UK (0xA589)

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -47,6 +47,7 @@ SUPPORTED_TYPES = {
     0x7583: (sp4, "SP mini 3", "Broadlink"),
     0x7D11: (sp4, "SP mini 3", "Broadlink"),
     0xA56A: (sp4, "MCB1", "Broadlink"),
+    0xA589: (sp4, "SP4L-UK", "Broadlink"),
     0x6113: (sp4b, "SCB1E", "Broadlink"),
     0x618B: (sp4b, "SP4L-EU", "Broadlink"),
     0x648B: (sp4b, "SP4M-US", "Broadlink"),


### PR DESCRIPTION
Add support for [Broadlink SP4L-UK (0xA589)](https://github.com/home-assistant/core/issues/40191#issuecomment-740751695).