### PR TITLE
Improve support for sp4b class sensors

### DIFF
--- a/broadlink/switch.py
+++ b/broadlink/switch.py
@@ -311,6 +311,18 @@ class sp4b(sp4):
         device.__init__(self, *args, **kwargs)
         self.type = "SP4B"
 
+    def get_state(self) -> dict:
+        """Get full state of device."""
+        state = super().get_state()
+
+        # Convert sensor data to float. Remove keys if sensors are not supported.
+        sensor_attrs = ["current", "volt", "power", "totalconsum", "overload"]
+        for attr in sensor_attrs:
+            value = state.pop(attr, -1)
+            if value != -1:
+                state[attr] = value / 1000
+        return state
+
     def _encode(self, flag: int, state: dict) -> bytes:
         """Encode a message."""
         payload = json.dumps(state, separators=(",", ":")).encode()


### PR DESCRIPTION
## Proposed changes
Thanks to @Mister-Slowhand now we know more about the sp4b class. This firmware supports USB and energy monitoring. Not all devices of this class have sensors, but most of them return the keys in response (current, volt, power, totalconsum, overload). Samples:

### SCB1E (0x6113)
```python3
>>> d.get_state()
{'pwr': 1, 'indicator': 1, 'maxworktime': 0, 'current': 8169, 'volt': 234600, 'power': 1916480, 'totalconsum': 10, 'overload': 0, 'childlock': 0}
```
### SP4 (0x618B)
```python3
>>> d.get_state()
{'pwr': 1, 'ntlight': 0, 'indicator': 1, 'usbpwr': 0, 'maxworktime': 0, 'usbmaxworktime': 0, 'ntlbrightness': 100, 'current': -1, 'volt': -1, 'power': -1, 'totalconsum': -1, 'overload': -1, 'childlock': 0}
```
They return -1 when sensors are not supported, as you can see in the second response. So I am introducing a filter to eliminate these keys.

## Before
```python3
>>> d.get_state()
{'pwr': 1, 'indicator': 1, 'maxworktime': 0, 'current': -1, 'volt': -1, 'power': -1, 'totalconsum': -1, 'overload': -1, 'childlock': 0}
```

## After
```python3
>>> d.get_state()
{'pwr': 1, 'indicator': 1, 'maxworktime': 0, 'childlock': 0}
```

I am also converting the values to float when sensors are supported.

## Before
```python3
>>> d.get_state()
{'pwr': 1, 'indicator': 1, 'maxworktime': 0, 'current': 8169, 'volt': 234600, 'power': 1916480, 'totalconsum': 10, 'overload': 0, 'childlock': 0}
```

## After
```python3
>>> d.get_state()
{'pwr': 1, 'indicator': 1, 'maxworktime': 0, 'childlock': 0, 'current': 8.169, 'volt': 234.6, 'power': 1916.48, 'totalconsum': 0.01, 'overload': 0.0}
```
