### PR TITLE
Add support for BG Electrical AHC/U-01 (0x51E2)

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -48,6 +48,7 @@ SUPPORTED_TYPES = {
     0x7D11: (sp4, "SP mini 3", "Broadlink"),
     0xA56A: (sp4, "MCB1", "Broadlink"),
     0xA589: (sp4, "SP4L-UK", "Broadlink"),
+    0x51E2: (sp4b, "AHC/U-01", "BG Electrical"),
     0x6113: (sp4b, "SCB1E", "Broadlink"),
     0x618B: (sp4b, "SP4L-EU", "Broadlink"),
     0x6489: (sp4b, "SP4L-AU", "Broadlink"),


### PR DESCRIPTION
This smart plug can be controlled with the SP4B class.

```python3
>>> d.get_state()
{'pwr': 0, 'maxworktime': 0, 'childlock': 0}
```

From: https://github.com/home-assistant/core/issues/44216

Thank you @cbear92!