### PR TITLE
Add support for Broadlink SP4L-AU (0x6489)

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -50,6 +50,7 @@ SUPPORTED_TYPES = {
     0xA589: (sp4, "SP4L-UK", "Broadlink"),
     0x6113: (sp4b, "SCB1E", "Broadlink"),
     0x618B: (sp4b, "SP4L-EU", "Broadlink"),
+    0x6489: (sp4b, "SP4L-AU", "Broadlink"),
     0x648B: (sp4b, "SP4M-US", "Broadlink"),
     0x2712: (rm, "RM pro/pro+", "Broadlink"),
     0x272A: (rm, "RM pro", "Broadlink"),


### PR DESCRIPTION
Add support for Broadlink SP4L-AU (0x6489).

From: https://github.com/home-assistant/core/issues/44530.

Thank you @DaveOzzie!