### PR TITLE
Revert retry_intvl

### DIFF
--- a/broadlink/device.py
+++ b/broadlink/device.py
@@ -262,7 +262,7 @@ class device:
         """Return device type."""
         return self.type
 
-    def send_packet(self, command: int, payload: bytes, retry_intvl: float = 1.0) -> bytes:
+    def send_packet(self, command: int, payload: bytes) -> bytes:
         """Send a packet to the device."""
         self.count = ((self.count + 1) | 0x8000) & 0xFFFF
         packet = bytearray(0x38)
@@ -315,7 +315,7 @@ class device:
 
                 while True:
                     time_left = timeout - (time.time() - start_time)
-                    conn.settimeout(min(retry_intvl, time_left))
+                    conn.settimeout(min(1, time_left))
                     conn.sendto(packet, self.host)
 
                     try:

--- a/broadlink/remote.py
+++ b/broadlink/remote.py
@@ -13,10 +13,10 @@ class rm(device):
         device.__init__(self, *args, **kwargs)
         self.type = "RM2"
 
-    def _send(self, command: int, data: bytes = b'', retry_intvl: float = 1.0) -> bytes:
+    def _send(self, command: int, data: bytes = b'') -> bytes:
         """Send a packet to the device."""
         packet = struct.pack("<I", command) + data
-        resp = self.send_packet(0x6A, packet, retry_intvl=retry_intvl)
+        resp = self.send_packet(0x6A, packet)
         check_error(resp[0x22:0x24])
         payload = self.decrypt(resp[0x38:])
         return payload[0x4:]
@@ -27,7 +27,7 @@ class rm(device):
 
     def send_data(self, data: bytes) -> None:
         """Send a code to the device."""
-        self._send(0x2, data=data, retry_intvl=5)
+        self._send(0x2, data)
 
     def enter_learning(self) -> None:
         """Enter infrared learning mode."""
@@ -71,10 +71,10 @@ class rm4(rm):
         device.__init__(self, *args, **kwargs)
         self.type = "RM4"
 
-    def _send(self, command: int, data: bytes = b'', retry_intvl: float = 1.0) -> bytes:
+    def _send(self, command: int, data: bytes = b'') -> bytes:
         """Send a packet to the device."""
         packet = struct.pack("<HI", len(data) + 4, command) + data
-        resp = self.send_packet(0x6A, packet, retry_intvl=retry_intvl)
+        resp = self.send_packet(0x6A, packet)
         check_error(resp[0x22:0x24])
         payload = self.decrypt(resp[0x38:])
         p_len = struct.unpack("<H", payload[:0x2])[0]


### PR DESCRIPTION
I am reverting [this commit](https://github.com/mjg59/python-broadlink/pull/464/commits/6af6cff36d4ba200a9389691d4cbcde8c937734b) to avoid introducing minor changes in the next release. The idea is to release 0.16.1 only with PIDs and protocol improvements and save all new features and interface improvements for 0.17.