### PR TITLE
Add support for Broadlink MCB1 (0x6111)

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -41,6 +41,7 @@ SUPPORTED_TYPES = {
     0x7D0D: (sp2, "SP mini 3", "Broadlink (OEM)"),
     0x9479: (sp2, "SP3S-US", "Broadlink"),
     0x947A: (sp2, "SP3S-EU", "Broadlink"),
+    0x6111: (sp4, "MCB1", "Broadlink"),
     0x756C: (sp4, "SP4M", "Broadlink"),
     0x756F: (sp4, "MCB1", "Broadlink"),
     0x7579: (sp4, "SP4L-EU", "Broadlink"),


### PR DESCRIPTION
Add support for Broadlink MCB1 (0x6111).

From: https://community.home-assistant.io/t/broadlink-devices/266384/2