### PR TITLE
Add support for Broadlink MCB1 (0x6111)

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -49,6 +49,7 @@ SUPPORTED_TYPES = {
     0xA56A: (sp4, "MCB1", "Broadlink"),
     0xA589: (sp4, "SP4L-UK", "Broadlink"),
     0x51E2: (sp4b, "AHC/U-01", "BG Electrical"),
+    0x6111: (sp4b, "MCB1", "Broadlink"),
     0x6113: (sp4b, "SCB1E", "Broadlink"),
     0x618B: (sp4b, "SP4L-EU", "Broadlink"),
     0x6489: (sp4b, "SP4L-AU", "Broadlink"),


### PR DESCRIPTION
Add support for Broadlink MCB1 (0x6111).

From: https://community.home-assistant.io/t/broadlink-devices/266384/2