### PR TITLE
Fix rm4.find_rf_packet()

### DIFF
--- a/broadlink/remote.py
+++ b/broadlink/remote.py
@@ -46,10 +46,9 @@ class rm(device):
         resp = self._send(0x1A)
         return resp[0] == 1
 
-    def find_rf_packet(self) -> bool:
+    def find_rf_packet(self) -> None:
         """Enter radiofrequency learning mode."""
-        resp = self._send(0x1B)
-        return resp[0] == 1
+        self._send(0x1B)
 
     def check_temperature(self) -> float:
         """Return the temperature."""


### PR DESCRIPTION
## The problem
The RM4 series came with some protocol improvements that went unnoticed in our initial implementation. The previous devices sent 1 in response to rm.find_rf_packet(), which was redundant. If the message doesn't have an error code the result is necessarily valid, so RM4 pro doesn't send anything. We are expecting 0 or 1, as for the previous devices, but there is no payload. This causes an IndexError that prevents people from learning RF codes with RM4 pro.

## Proposed changes
- Return None in rm4.find_rf_packet().
- Return None in rm.find_rf_packet() in order to share the same interface between remotes.
- Do not check the payload. If there is no exception, it worked.

Fixes: https://github.com/mjg59/python-broadlink/issues/513