### PR TITLE
Split the sp2 class into smaller classes

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """The python-broadlink library."""
 import socket
-from typing import Generator, List, Union, Tuple
+from typing import Generator, List, Tuple, Union
 
 from .alarm import S1C
 from .climate import hysen
@@ -11,21 +11,16 @@ from .exceptions import exception
 from .light import lb1
 from .remote import rm, rm4
 from .sensor import a1
-from .switch import bg1, mp1, sp1, sp2, sp4, sp4b
-
+from .switch import bg1, mp1, sp1, sp2, sp2s, sp3, sp3s, sp4, sp4b
 
 SUPPORTED_TYPES = {
     0x0000: (sp1, "SP1", "Broadlink"),
     0x2711: (sp2, "SP2", "Broadlink"),
-    0x2716: (sp2, "NEO PRO", "Ankuoo"),
     0x2717: (sp2, "NEO", "Ankuoo"),
     0x2719: (sp2, "SP2-compatible", "Honeywell"),
     0x271A: (sp2, "SP2-compatible", "Honeywell"),
-    0x271D: (sp2, "Ego", "Efergy"),
     0x2720: (sp2, "SP mini", "Broadlink"),
     0x2728: (sp2, "SP2-compatible", "URANT"),
-    0x2733: (sp2, "SP3", "Broadlink"),
-    0x2736: (sp2, "SP mini+", "Broadlink"),
     0x273E: (sp2, "SP mini", "Broadlink"),
     0x7530: (sp2, "SP2", "Broadlink (OEM)"),
     0x7539: (sp2, "SP2-IL", "Broadlink (OEM)"),
@@ -37,10 +32,14 @@ SUPPORTED_TYPES = {
     0x7918: (sp2, "SP2", "Broadlink (OEM)"),
     0x7919: (sp2, "SP2-compatible", "Honeywell"),
     0x791A: (sp2, "SP2-compatible", "Honeywell"),
-    0x7D00: (sp2, "SP3-EU", "Broadlink (OEM)"),
     0x7D0D: (sp2, "SP mini 3", "Broadlink (OEM)"),
-    0x9479: (sp2, "SP3S-US", "Broadlink"),
-    0x947A: (sp2, "SP3S-EU", "Broadlink"),
+    0x2716: (sp2s, "NEO PRO", "Ankuoo"),
+    0x271D: (sp2s, "Ego", "Efergy"),
+    0x2736: (sp2s, "SP mini+", "Broadlink"),
+    0x2733: (sp3, "SP3", "Broadlink"),
+    0x7D00: (sp3, "SP3-EU", "Broadlink (OEM)"),
+    0x9479: (sp3s, "SP3S-US", "Broadlink"),
+    0x947A: (sp3s, "SP3S-EU", "Broadlink"),
     0x756C: (sp4, "SP4M", "Broadlink"),
     0x756F: (sp4, "MCB1", "Broadlink"),
     0x7579: (sp4, "SP4L-EU", "Broadlink"),

--- a/broadlink/switch.py
+++ b/broadlink/switch.py
@@ -164,6 +164,44 @@ class sp2(device):
         """Set the power state of the device."""
         packet = bytearray(16)
         packet[0] = 2
+        packet[4] = int(bool(state))
+        response = self.send_packet(0x6A, packet)
+        check_error(response[0x22:0x24])
+
+    def check_power(self) -> bool:
+        """Return the power state of the device."""
+        packet = bytearray(16)
+        packet[0] = 1
+        response = self.send_packet(0x6A, packet)
+        check_error(response[0x22:0x24])
+        payload = self.decrypt(response[0x38:])
+        return bool(payload[0x4])
+
+
+class sp2s(sp2):
+    """Controls a Broadlink SP2S."""
+
+    TYPE = "SP2S"
+
+    def get_energy(self) -> float:
+        """Return the power consumption in W."""
+        packet = bytearray(16)
+        packet[0] = 4
+        response = self.send_packet(0x6A, packet)
+        check_error(response[0x22:0x24])
+        payload = self.decrypt(response[0x38:])
+        return int.from_bytes(payload[0x4:0x7], "little") / 1000
+
+
+class sp3(device):
+    """Controls a Broadlink SP3."""
+
+    TYPE = "SP3"
+
+    def set_power(self, state: bool) -> None:
+        """Set the power state of the device."""
+        packet = bytearray(16)
+        packet[0] = 2
         if self.check_nightlight():
             packet[4] = 3 if state else 2
         else:
@@ -199,6 +237,12 @@ class sp2(device):
         check_error(response[0x22:0x24])
         payload = self.decrypt(response[0x38:])
         return bool(payload[0x4] == 2 or payload[0x4] == 3 or payload[0x4] == 0xFF)
+
+
+class sp3s(sp2):
+    """Controls a Broadlink SP3S."""
+
+    TYPE = "SP3S"
 
     def get_energy(self) -> float:
         """Return the power consumption in W."""


### PR DESCRIPTION
## Breaking change
Split the sp2 class into sp2, sp2s, sp3 and sp3s classes. Client applications that instantiate sp2 objects directly need to adapt their code to call check_nightlight(), set_nightlight() or get_energy() with the appropriate class. If they use hello(), discover() or xdiscover() the correct class will be selected automatically and they don't need to worry.

Now they can use duck typing to see if the feature is supported:
```python3
import broadlink as blk

def set_nightlight(device, state):
    if hasattr(device, "set_nightlight"):
        return device.set_nightlight(state)
    else:
        print("set_nightlight() is not supported by this device")

d = blk.hello('192.168.0.16')  # Any Broadlink device. Any type.
set_nightlight(d, True)
```

## The problem
1. Some SP2 devices support get_energy(), but the firmware is different, so we need to split classes and create another method.

2. The only device of the sp2 class that supports set_nightlight() and check_nightlight() is the SP3, so I am taking the opportunity to create an exclusive class for this device to improve typing.


## Proposed changes
- Create a new sp3 class with the check_nightlight() and set_nightlight() methods.
- Create a new sp3s with the current get_energy() method to support SP3S devices.
- Create a new sp2s class with a new get_energy() method to support SP mini+, NEO PRO and Efergy Ego.
- Remove the get_energy(), check_nightlight() and set_nightlight() methods from the sp2 class to improve typing.

fixes https://github.com/mjg59/python-broadlink/issues/413#issue-693577696
fixes https://github.com/mjg59/python-broadlink/issues/200#issuecomment-409548956