### PR TITLE
Make the type a class attribute

### DIFF
--- a/broadlink/alarm.py
+++ b/broadlink/alarm.py
@@ -6,16 +6,13 @@ from .exceptions import check_error
 class S1C(device):
     """Controls a Broadlink S1C."""
 
+    TYPE = "S1C"
+
     _SENSORS_TYPES = {
         0x31: "Door Sensor",  # 49 as hex
         0x91: "Key Fob",  # 145 as hex, as serial on fob corpse
         0x21: "Motion Sensor",  # 33 as hex
     }
-
-    def __init__(self, *args, **kwargs) -> None:
-        """Initialize the controller."""
-        device.__init__(self, *args, **kwargs)
-        self.type = "S1C"
 
     def get_sensors_status(self) -> dict:
         """Return the state of the sensors."""

--- a/broadlink/climate.py
+++ b/broadlink/climate.py
@@ -9,10 +9,7 @@ from .helpers import calculate_crc16
 class hysen(device):
     """Controls a Hysen HVAC."""
 
-    def __init__(self, *args, **kwargs) -> None:
-        """Initialize the controller."""
-        device.__init__(self, *args, **kwargs)
-        self.type = "Hysen heating controller"
+    TYPE = "Hysen heating controller"
 
     # Send a request
     # input_payload should be a bytearray, usually 6 bytes, e.g. bytearray([0x01,0x06,0x00,0x02,0x10,0x00])

--- a/broadlink/cover.py
+++ b/broadlink/cover.py
@@ -8,10 +8,7 @@ from .exceptions import check_error
 class dooya(device):
     """Controls a Dooya curtain motor."""
 
-    def __init__(self, *args, **kwargs) -> None:
-        """Initialize the controller."""
-        device.__init__(self, *args, **kwargs)
-        self.type = "Dooya DT360E"
+    TYPE = "Dooya DT360E"
 
     def _send(self, magic1: int, magic2: int) -> int:
         """Send a packet to the device."""

--- a/broadlink/device.py
+++ b/broadlink/device.py
@@ -87,6 +87,8 @@ def ping(address: str, port: int = 80) -> None:
 class device:
     """Controls a Broadlink device."""
 
+    TYPE = "Unknown"
+
     def __init__(
         self,
         host: Tuple[str, int],
@@ -110,7 +112,7 @@ class device:
         self.count = random.randint(0x8000, 0xFFFF)
         self.iv = bytes.fromhex("562e17996d093d28ddb3ba695a2e6f58")
         self.id = 0
-        self.type = "Unknown"
+        self.type = self.TYPE  # For backwards compatibility.
         self.lock = threading.Lock()
 
         self.aes = None

--- a/broadlink/light.py
+++ b/broadlink/light.py
@@ -11,17 +11,14 @@ from .exceptions import check_error
 class lb1(device):
     """Controls a Broadlink LB1."""
 
+    TYPE = "LB1"
+
     @enum.unique
     class ColorMode(enum.IntEnum):
         """Enumerates color modes."""
         RGB = 0
         WHITE = 1
         SCENE = 2
-
-    def __init__(self, *args, **kwargs) -> None:
-        """Initialize the controller."""
-        device.__init__(self, *args, **kwargs)
-        self.type = "LB1"
 
     def get_state(self) -> dict:
         """Return the power state of the device.

--- a/broadlink/remote.py
+++ b/broadlink/remote.py
@@ -8,10 +8,7 @@ from .exceptions import check_error
 class rm(device):
     """Controls a Broadlink RM."""
 
-    def __init__(self, *args, **kwargs) -> None:
-        """Initialize the controller."""
-        device.__init__(self, *args, **kwargs)
-        self.type = "RM2"
+    TYPE = "RM2"
 
     def _send(self, command: int, data: bytes = b'') -> bytes:
         """Send a packet to the device."""
@@ -65,10 +62,7 @@ class rm(device):
 class rm4(rm):
     """Controls a Broadlink RM4."""
 
-    def __init__(self, *args, **kwargs) -> None:
-        """Initialize the controller."""
-        device.__init__(self, *args, **kwargs)
-        self.type = "RM4"
+    TYPE = "RM4"
 
     def _send(self, command: int, data: bytes = b'') -> bytes:
         """Send a packet to the device."""

--- a/broadlink/sensor.py
+++ b/broadlink/sensor.py
@@ -8,16 +8,13 @@ from .exceptions import check_error
 class a1(device):
     """Controls a Broadlink A1."""
 
+    TYPE = "A1"
+
     _SENSORS_AND_LEVELS = (
         ("light", ("dark", "dim", "normal", "bright")),
         ("air_quality", ("excellent", "good", "normal", "bad")),
         ("noise", ("quiet", "normal", "noisy")),
     )
-
-    def __init__(self, *args, **kwargs) -> None:
-        """Initialize the controller."""
-        device.__init__(self, *args, **kwargs)
-        self.type = "A1"
 
     def check_sensors(self) -> dict:
         """Return the state of the sensors."""

--- a/broadlink/switch.py
+++ b/broadlink/switch.py
@@ -9,10 +9,7 @@ from .exceptions import check_error
 class mp1(device):
     """Controls a Broadlink MP1."""
 
-    def __init__(self, *args, **kwargs) -> None:
-        """Initialize the controller."""
-        device.__init__(self, *args, **kwargs)
-        self.type = "MP1"
+    TYPE = "MP1"
 
     def set_power_mask(self, sid_mask: int, state: bool) -> None:
         """Set the power state of the device."""
@@ -70,10 +67,7 @@ class mp1(device):
 class bg1(device):
     """Controls a BG Electrical smart outlet."""
 
-    def __init__(self, *args, **kwargs) -> None:
-        """Initialize the controller."""
-        device.__init__(self, *args, **kwargs)
-        self.type = "BG1"
+    TYPE = "BG1"
 
     def get_state(self) -> dict:
         """Return the power state of the device.
@@ -151,10 +145,7 @@ class bg1(device):
 class sp1(device):
     """Controls a Broadlink SP1."""
 
-    def __init__(self, *args, **kwargs) -> None:
-        """Initialize the device."""
-        device.__init__(self, *args, **kwargs)
-        self.type = "SP1"
+    TYPE = "SP1"
 
     def set_power(self, state: bool) -> None:
         """Set the power state of the device."""
@@ -167,10 +158,7 @@ class sp1(device):
 class sp2(device):
     """Controls a Broadlink SP2."""
 
-    def __init__(self, *args, **kwargs) -> None:
-        """Initialize the controller."""
-        device.__init__(self, *args, **kwargs)
-        self.type = "SP2"
+    TYPE = "SP2"
 
     def set_power(self, state: bool) -> None:
         """Set the power state of the device."""
@@ -225,10 +213,7 @@ class sp2(device):
 class sp4(device):
     """Controls a Broadlink SP4."""
 
-    def __init__(self, *args, **kwargs) -> None:
-        """Initialize the controller."""
-        device.__init__(self, *args, **kwargs)
-        self.type = "SP4"
+    TYPE = "SP4"
 
     def set_power(self, state: bool) -> None:
         """Set the power state of the device."""
@@ -307,10 +292,7 @@ class sp4(device):
 class sp4b(sp4):
     """Controls a Broadlink SP4 (type B)."""
 
-    def __init__(self, *args, **kwargs) -> None:
-        """Initialize the controller."""
-        device.__init__(self, *args, **kwargs)
-        self.type = "SP4B"
+    TYPE = "SP4B"
 
     def get_state(self) -> dict:
         """Get full state of device."""


### PR DESCRIPTION
The type should be a class attribute. It does not vary and is common to all objects in the same class. This update allow us to access the type without the need to instantiate an object:
```python3
>>> import broadlink as blk
>>> d = blk.sp4
>>> print(sp4.TYPE)
"SP4"
```
It will help us to improve the factory function and build unknown devices more easily. Wait for it.