### PR TITLE
Add auto-publish mechanism

### DIFF
--- a/.github/workflows/auto-publish.yaml
+++ b/.github/workflows/auto-publish.yaml
@@ -1,0 +1,28 @@
+name: Auto-Publish to PyPi
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload dist/*


### PR DESCRIPTION
In order for this to work once merged, @mjg59 needs to go to this repo's settings, choose "Secrets", and add the secrets `PYPI_USERNAME` and `PYPI_PASSWORD`. Then whenever a GitHub release is published, it should also be published to PyPi.