### PR TITLE
Add support for Broadlink SCB2 (0x6494)

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -54,6 +54,7 @@ SUPPORTED_TYPES = {
     0x618B: (sp4b, "SP4L-EU", "Broadlink"),
     0x6489: (sp4b, "SP4L-AU", "Broadlink"),
     0x648B: (sp4b, "SP4M-US", "Broadlink"),
+    0x6494: (sp4b, "SCB2", "Broadlink"),
     0x2737: (rmmini, "RM mini 3", "Broadlink"),
     0x278F: (rmmini, "RM mini", "Broadlink"),
     0x27C2: (rmmini, "RM mini 3", "Broadlink"),


### PR DESCRIPTION
Add support for Broadlink SCB2 (0x6494). We can control this device with the sp4b class, but it's not the ideal, because the response to get_state() is different:
```python3
{'pwr': 1, 'indicator': 1, 'maxworktime': 0, 'childlock': 0}
```
I will create a separate class for this and other smart control boxes as soon as I finish a rework I am doing in another PR.

Thank you for the tests @MichielioZ!

fixes https://github.com/mjg59/python-broadlink/issues/556