### PR TITLE
Add new SP4L-UK type and fix checking state return bool

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -47,6 +47,7 @@ SUPPORTED_TYPES = {
     0x7D11: (sp4, "SP mini 3", "Broadlink"),
     0xA56A: (sp4, "MCB1", "Broadlink"),
     0xA589: (sp4, "SP4L-UK", "Broadlink"),
+    0x7587: (sp4, "SP4L-UK", "Broadlink"),
     0x5115: (sp4b, "SCB1E", "Broadlink"),
     0x51E2: (sp4b, "AHC/U-01", "BG Electrical"),
     0x6111: (sp4b, "MCB1", "Broadlink"),

--- a/broadlink/switch.py
+++ b/broadlink/switch.py
@@ -298,12 +298,12 @@ class sp4(device):
     def check_power(self) -> bool:
         """Return the power state of the device."""
         state = self.get_state()
-        return state["pwr"]
+        return bool(state["pwr"])
 
     def check_nightlight(self) -> bool:
         """Return the state of the night light."""
         state = self.get_state()
-        return state["ntlight"]
+        return bool(state["ntlight"])
 
     def get_state(self) -> dict:
         """Get full state of device."""


### PR DESCRIPTION
- Add new SP4L-UK type
- Switch: SP4 check power and nightlight to return as boolean …
  - Instead of int
  - Consistency with sp2's check_power
    - https://github.com/mjg59/python-broadlink/blob/master/broadlink/switch.py#L178

### Screenshot
#### Adding new SP4L-UK
![image](https://user-images.githubusercontent.com/6790008/112286117-f1e9a800-8cc5-11eb-9f53-815f698c9f0d.png)

#### Checking power and nightlight state before and after turning them on
![image](https://user-images.githubusercontent.com/6790008/112286161-fd3cd380-8cc5-11eb-839b-57b38a7737de.png)


@felipediel 