### PR TITLE
Improve CRC-16 function

### DIFF
--- a/broadlink/climate.py
+++ b/broadlink/climate.py
@@ -3,7 +3,7 @@ from typing import List
 
 from . import exceptions as e
 from .device import device
-from .helpers import calculate_crc16
+from .helpers import crc16
 
 
 class hysen(device):
@@ -19,7 +19,7 @@ class hysen(device):
 
     def send_request(self, input_payload: bytes) -> bytes:
         """Send a request to the device."""
-        crc = calculate_crc16(input_payload)
+        crc = crc16(input_payload)
 
         # first byte is length, +2 for CRC16
         request_payload = bytearray([len(input_payload) + 2, 0x00])
@@ -40,7 +40,7 @@ class hysen(device):
             raise ValueError(
                 "hysen_response_error", "first byte of response is not length"
             )
-        crc = calculate_crc16(response_payload[2:response_payload_len])
+        crc = crc16(response_payload[2:response_payload_len])
         if (response_payload[response_payload_len] == crc & 0xFF) and (
             response_payload[response_payload_len + 1] == (crc >> 8) & 0xFF
         ):

--- a/broadlink/helpers.py
+++ b/broadlink/helpers.py
@@ -12,16 +12,15 @@ def crc16(
     for dividend in range(0, 256):
         remainder = dividend
         for _ in range(0, 8):
-            if remainder & 0x0001:
-                remainder = remainder >> 1 & 0xFFFF ^ polynomial
+            if remainder & 1:
+                remainder = remainder >> 1 ^ polynomial
             else:
-                remainder = remainder >> 1 & 0xFFFF
+                remainder = remainder >> 1
         crc_table.append(remainder)
 
     crc = init_value
     for item in sequence:
-        index = (crc ^ item) & 0x00FF
-        base = crc >> 8 & 0xFFFF
+        index = (crc ^ item) & 0xFF
+        base = crc >> 8
         crc = base ^ crc_table[index]
-
     return crc

--- a/broadlink/helpers.py
+++ b/broadlink/helpers.py
@@ -6,7 +6,7 @@ _crc16_cache = {}
 
 def crc16(
     sequence: t.Sequence[int],
-    polynomial: int = 0xA001,
+    polynomial: int = 0xA001,  # Default: Modbus CRC-16.
     init_value: int = 0xFFFF,
 ) -> int:
     """Calculate the CRC-16 of a sequence of integers."""
@@ -28,7 +28,5 @@ def crc16(
 
     crc = init_value
     for item in sequence:
-        index = (crc ^ item) & 0xFF
-        base = crc >> 8
-        crc = base ^ crc_table[index]
+        crc = crc >> 8 ^ crc_table[(crc ^ item) & 0xFF]
     return crc

--- a/broadlink/helpers.py
+++ b/broadlink/helpers.py
@@ -1,6 +1,8 @@
 """Helper functions."""
 import typing as t
 
+_crc16_cache = {}
+
 
 def crc16(
     sequence: t.Sequence[int],
@@ -8,15 +10,21 @@ def crc16(
     init_value=0xFFFF,
 ) -> int:
     """Calculate the CRC-16 of a byte string."""
-    crc_table = []
-    for dividend in range(0, 256):
-        remainder = dividend
-        for _ in range(0, 8):
-            if remainder & 1:
-                remainder = remainder >> 1 ^ polynomial
-            else:
-                remainder = remainder >> 1
-        crc_table.append(remainder)
+    global _crc16_cache
+
+    try:
+        crc_table = _crc16_cache[polynomial]
+    except KeyError:
+        crc_table = []
+        for dividend in range(0, 256):
+            remainder = dividend
+            for _ in range(0, 8):
+                if remainder & 1:
+                    remainder = remainder >> 1 ^ polynomial
+                else:
+                    remainder = remainder >> 1
+            crc_table.append(remainder)
+        _crc16_cache[polynomial] = crc_table
 
     crc = init_value
     for item in sequence:

--- a/broadlink/helpers.py
+++ b/broadlink/helpers.py
@@ -1,11 +1,14 @@
 """Helper functions."""
 import typing as t
 
-def crc16(sequence: t.Sequence[int]) -> int:
+
+def crc16(
+    sequence: t.Sequence[int],
+    polynomial=0xA001,
+    init_value=0xFFFF,
+) -> int:
     """Calculate the CRC-16 of a byte string."""
     crc_table = []
-    polynomial = 0xA001
-
     for dividend in range(0, 256):
         remainder = dividend
         for _ in range(0, 8):
@@ -15,8 +18,7 @@ def crc16(sequence: t.Sequence[int]) -> int:
                 remainder = remainder >> 1 & 0xFFFF
         crc_table.append(remainder)
 
-    crc = 0xFFFF
-
+    crc = init_value
     for item in sequence:
         index = (crc ^ item) & 0x00FF
         base = crc >> 8 & 0xFFFF

--- a/broadlink/helpers.py
+++ b/broadlink/helpers.py
@@ -6,8 +6,8 @@ _crc16_cache = {}
 
 def crc16(
     sequence: t.Sequence[int],
-    polynomial=0xA001,
-    init_value=0xFFFF,
+    polynomial: int = 0xA001,
+    init_value: int = 0xFFFF,
 ) -> int:
     """Calculate the CRC-16 of a byte string."""
     global _crc16_cache

--- a/broadlink/helpers.py
+++ b/broadlink/helpers.py
@@ -13,13 +13,13 @@ def crc16(sequence: t.Sequence[int]) -> int:
                 remainder = remainder >> 1 & 0xFFFF ^ polynomial
             else:
                 remainder = remainder >> 1 & 0xFFFF
-        crc_table.append(hex(remainder))
+        crc_table.append(remainder)
 
     crc = 0xFFFF
 
     for item in sequence:
         index = (crc ^ item) & 0x00FF
         base = crc >> 8 & 0xFFFF
-        crc = base ^ int(crc_table[index], 0)
+        crc = base ^ crc_table[index]
 
     return crc

--- a/broadlink/helpers.py
+++ b/broadlink/helpers.py
@@ -9,7 +9,7 @@ def crc16(
     polynomial: int = 0xA001,
     init_value: int = 0xFFFF,
 ) -> int:
-    """Calculate the CRC-16 of a byte string."""
+    """Calculate the CRC-16 of a sequence of integers."""
     global _crc16_cache
 
     try:

--- a/broadlink/helpers.py
+++ b/broadlink/helpers.py
@@ -1,6 +1,7 @@
 """Helper functions."""
+import typing as t
 
-def crc16(sequence: bytes) -> int:
+def crc16(sequence: t.Sequence[int]) -> int:
     """Calculate the CRC-16 of a byte string."""
     crc_table = []
     polynomial = 0xA001

--- a/broadlink/helpers.py
+++ b/broadlink/helpers.py
@@ -1,6 +1,4 @@
 """Helper functions."""
-from ctypes import c_ushort
-
 
 def crc16(sequence: bytes) -> int:
     """Calculate the CRC-16 of a byte string."""
@@ -8,19 +6,19 @@ def crc16(sequence: bytes) -> int:
     polynomial = 0xA001
 
     for dividend in range(0, 256):
-        remainder = c_ushort(dividend).value
+        remainder = dividend
         for _ in range(0, 8):
             if remainder & 0x0001:
-                remainder = c_ushort(remainder >> 1).value ^ polynomial
+                remainder = remainder >> 1 & 0xFFFF ^ polynomial
             else:
-                remainder = c_ushort(remainder >> 1).value
+                remainder = remainder >> 1 & 0xFFFF
         crc_table.append(hex(remainder))
 
     crc = 0xFFFF
 
     for item in sequence:
         index = (crc ^ item) & 0x00FF
-        base = c_ushort(crc >> 8).value
+        base = crc >> 8 & 0xFFFF
         crc = base ^ int(crc_table[index], 0)
 
     return crc

--- a/broadlink/helpers.py
+++ b/broadlink/helpers.py
@@ -2,7 +2,7 @@
 from ctypes import c_ushort
 
 
-def calculate_crc16(input_data: bytes) -> int:
+def crc16(input_data: bytes) -> int:
     """Calculate the CRC-16 of a byte string."""
     crc16_tab = []
     crc16_constant = 0xA001

--- a/broadlink/helpers.py
+++ b/broadlink/helpers.py
@@ -2,25 +2,25 @@
 from ctypes import c_ushort
 
 
-def crc16(input_data: bytes) -> int:
+def crc16(sequence: bytes) -> int:
     """Calculate the CRC-16 of a byte string."""
-    crc16_tab = []
-    crc16_constant = 0xA001
+    crc_table = []
+    polynomial = 0xA001
 
-    for i in range(0, 256):
-        crc = c_ushort(i).value
-        for j in range(0, 8):
-            if crc & 0x0001:
-                crc = c_ushort(crc >> 1).value ^ crc16_constant
+    for dividend in range(0, 256):
+        remainder = c_ushort(dividend).value
+        for _ in range(0, 8):
+            if remainder & 0x0001:
+                remainder = c_ushort(remainder >> 1).value ^ polynomial
             else:
-                crc = c_ushort(crc >> 1).value
-        crc16_tab.append(hex(crc))
+                remainder = c_ushort(remainder >> 1).value
+        crc_table.append(hex(remainder))
 
-    crcValue = 0xFFFF
+    crc = 0xFFFF
 
-    for c in input_data:
-        tmp = crcValue ^ c
-        rotated = c_ushort(crcValue >> 8).value
-        crcValue = rotated ^ int(crc16_tab[(tmp & 0x00FF)], 0)
+    for item in sequence:
+        index = (crc ^ item) & 0x00FF
+        base = c_ushort(crc >> 8).value
+        crc = base ^ int(crc_table[index], 0)
 
-    return crcValue
+    return crc


### PR DESCRIPTION
## Proposed changes
- Rename calculate_crc16 to crc16
- Apply PEP-8 naming conventions
- Remove unnecessary c_ushort type casting
- Remove unnecessary conversions
- Remove unnecessary bitwise operations
- Accept any sequence type
- Expose polynomial and initial value as kwargs
- Store the CRC-16 table for performance

## Performance test

```python3
>>> import broadlink as blk
>>> from functools import partial
>>> from timeit import timeit
>>> b = bytearray(range(255))

# Before
>>> timeit(partial(blk.helpers.calculate_crc16, b))
826.9239850719969

# After
>>> timeit(partial(blk.helpers.crc16, b))
40.797150269994745
```