### PR TITLE
Raise exceptions explicitly

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -151,8 +151,12 @@ def hello(
     """
     try:
         return next(xdiscover(timeout, local_ip_address, host, port))
-    except StopIteration:
-        raise e.exception(-4000)  # Network timeout.
+    except StopIteration as err:
+        raise e.NetworkTimeoutError(
+            -4000,
+            "Network timeout",
+            f"No response received within {timeout}s",
+        ) from err
 
 
 def discover(


### PR DESCRIPTION
Explicit is better than implicit. Remove comments, raise exceptions explicitly and improve error messages.