### PR TITLE
Use CamelCase for the Device class

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -7,7 +7,7 @@ from . import exceptions as e
 from .alarm import S1C
 from .climate import hysen
 from .cover import dooya
-from .device import device, ping, scan
+from .device import Device, ping, scan
 from .light import lb1, lb27r1
 from .remote import rm, rm4, rm4mini, rm4pro, rmmini, rmminib, rmpro
 from .sensor import a1
@@ -120,13 +120,13 @@ def gendevice(
     mac: t.Union[bytes, str],
     name: str = None,
     is_locked: bool = None,
-) -> device:
+) -> Device:
     """Generate a device."""
     try:
         dev_class, model, manufacturer = SUPPORTED_TYPES[dev_type]
 
     except KeyError:
-        return device(host, mac, dev_type, name=name, is_locked=is_locked)
+        return Device(host, mac, dev_type, name=name, is_locked=is_locked)
 
     return dev_class(
         host,
@@ -144,7 +144,7 @@ def hello(
     port: int = 80,
     timeout: int = 10,
     local_ip_address: str = None,
-) -> device:
+) -> Device:
     """Direct device discovery.
 
     Useful if the device is locked.
@@ -164,7 +164,7 @@ def discover(
     local_ip_address: str = None,
     discover_ip_address: str = "255.255.255.255",
     discover_ip_port: int = 80,
-) -> t.List[device]:
+) -> t.List[Device]:
     """Discover devices connected to the local network."""
     responses = scan(timeout, local_ip_address, discover_ip_address, discover_ip_port)
     return [gendevice(*resp) for resp in responses]
@@ -175,7 +175,7 @@ def xdiscover(
     local_ip_address: str = None,
     discover_ip_address: str = "255.255.255.255",
     discover_ip_port: int = 80,
-) -> t.Generator[device, None, None]:
+) -> t.Generator[Device, None, None]:
     """Discover devices connected to the local network.
 
     This function returns a generator that yields devices instantly.

--- a/broadlink/alarm.py
+++ b/broadlink/alarm.py
@@ -1,9 +1,9 @@
 """Support for alarm kits."""
 from . import exceptions as e
-from .device import device
+from .device import Device
 
 
-class S1C(device):
+class S1C(Device):
     """Controls a Broadlink S1C."""
 
     TYPE = "S1C"

--- a/broadlink/climate.py
+++ b/broadlink/climate.py
@@ -2,11 +2,11 @@
 from typing import List
 
 from . import exceptions as e
-from .device import device
+from .device import Device
 from .helpers import CRC16
 
 
-class hysen(device):
+class hysen(Device):
     """Controls a Hysen HVAC."""
 
     TYPE = "Hysen heating controller"

--- a/broadlink/cover.py
+++ b/broadlink/cover.py
@@ -2,10 +2,10 @@
 import time
 
 from . import exceptions as e
-from .device import device
+from .device import Device
 
 
-class dooya(device):
+class dooya(Device):
     """Controls a Dooya curtain motor."""
 
     TYPE = "Dooya DT360E"

--- a/broadlink/device.py
+++ b/broadlink/device.py
@@ -84,7 +84,7 @@ def ping(address: str, port: int = 80) -> None:
         conn.sendto(packet, (address, port))
 
 
-class device:
+class Device:
     """Controls a Broadlink device."""
 
     TYPE = "Unknown"

--- a/broadlink/light.py
+++ b/broadlink/light.py
@@ -5,10 +5,10 @@ import struct
 import typing as t
 
 from . import exceptions as e
-from .device import device
+from .device import Device
 
 
-class lb1(device):
+class lb1(Device):
     """Controls a Broadlink LB1."""
 
     TYPE = "LB1"
@@ -105,7 +105,7 @@ class lb1(device):
         return state
 
 
-class lb27r1(device):
+class lb27r1(Device):
     """Controls a Broadlink LB27 R1."""
 
     TYPE = "LB27R1"

--- a/broadlink/remote.py
+++ b/broadlink/remote.py
@@ -2,10 +2,10 @@
 import struct
 
 from . import exceptions as e
-from .device import device
+from .device import Device
 
 
-class rmmini(device):
+class rmmini(Device):
     """Controls a Broadlink RM mini 3."""
 
     TYPE = "RMMINI"

--- a/broadlink/sensor.py
+++ b/broadlink/sensor.py
@@ -2,10 +2,10 @@
 import struct
 
 from . import exceptions as e
-from .device import device
+from .device import Device
 
 
-class a1(device):
+class a1(Device):
     """Controls a Broadlink A1."""
 
     TYPE = "A1"

--- a/broadlink/switch.py
+++ b/broadlink/switch.py
@@ -3,10 +3,10 @@ import json
 import struct
 
 from . import exceptions as e
-from .device import device
+from .device import Device
 
 
-class mp1(device):
+class mp1(Device):
     """Controls a Broadlink MP1."""
 
     TYPE = "MP1"
@@ -64,7 +64,7 @@ class mp1(device):
         return data
 
 
-class bg1(device):
+class bg1(Device):
     """Controls a BG Electrical smart outlet."""
 
     TYPE = "BG1"
@@ -142,7 +142,7 @@ class bg1(device):
         return state
 
 
-class sp1(device):
+class sp1(Device):
     """Controls a Broadlink SP1."""
 
     TYPE = "SP1"
@@ -155,7 +155,7 @@ class sp1(device):
         e.check_error(response[0x22:0x24])
 
 
-class sp2(device):
+class sp2(Device):
     """Controls a Broadlink SP2."""
 
     TYPE = "SP2"
@@ -193,7 +193,7 @@ class sp2s(sp2):
         return int.from_bytes(payload[0x4:0x7], "little") / 1000
 
 
-class sp3(device):
+class sp3(Device):
     """Controls a Broadlink SP3."""
 
     TYPE = "SP3"
@@ -254,7 +254,7 @@ class sp3s(sp2):
         return int(energy) / 100
 
 
-class sp4(device):
+class sp4(Device):
     """Controls a Broadlink SP4."""
 
     TYPE = "SP4"


### PR DESCRIPTION
Use CamelCase for the Device class, for PEP-8 compliance. I checked the main client applications and none will be affected by this change.