### PR TITLE
Use the absolute position to read the lock status

### DIFF
--- a/broadlink/device.py
+++ b/broadlink/device.py
@@ -64,7 +64,7 @@ def scan(
                 discovered.append((host, mac, devtype))
 
                 name = resp[0x40:].split(b"\x00")[0].decode()
-                is_locked = bool(resp[-1])
+                is_locked = bool(resp[0x7F])
                 yield devtype, host, mac, name, is_locked
     finally:
         conn.close()


### PR DESCRIPTION
Some newer devices (including [LB1](https://github.com/mjg59/python-broadlink/issues/571#issuecomment-812910832)) are appending extra information to the Server Hello packet, making the lock status no longer represented by the last byte. Using the absolute position to read the lock status will fix.