### PR TITLE
Add support for Broadlink RM mini 3 (0x4E2A)

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -67,6 +67,7 @@ SUPPORTED_TYPES = {
     0x27D1: (rmmini, "RM mini 3", "Broadlink"),
     0x27D3: (rmmini, "RM mini 3", "Broadlink"),
     0x27DE: (rmmini, "RM mini 3", "Broadlink"),
+    0x4E2A: (rmmini, "RM mini 3", "Broadlink"),
     0x2712: (rmpro, "RM pro/pro+", "Broadlink"),
     0x272A: (rmpro, "RM pro", "Broadlink"),
     0x273D: (rmpro, "RM pro", "Broadlink"),


### PR DESCRIPTION
We found a new RM mini 3. The device type is in a different range. There is probably some difference in the protocol. Time will tell.
Thank you @Stefos13!

closes https://github.com/mjg59/python-broadlink/issues/580