### PR TITLE
Add support for Broadlink SP4L-EU (0xA5D3)

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -49,6 +49,7 @@ SUPPORTED_TYPES = {
     0x7D11: (sp4, "SP mini 3", "Broadlink"),
     0xA56A: (sp4, "MCB1", "Broadlink"),
     0xA589: (sp4, "SP4L-UK", "Broadlink"),
+    0xA5D3: (sp4, "SP4L-EU", "Broadlink"),
     0x5115: (sp4b, "SCB1E", "Broadlink"),
     0x51E2: (sp4b, "AHC/U-01", "BG Electrical"),
     0x6111: (sp4b, "MCB1", "Broadlink"),


### PR DESCRIPTION
From: https://github.com/home-assistant/core/issues/49596.

Thank you @dawik!