### PR TITLE
Rename lb27r1 class to lb2

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -9,7 +9,7 @@ from .alarm import S1C
 from .climate import hysen
 from .cover import dooya
 from .device import Device, ping, scan
-from .light import lb1, lb27r1
+from .light import lb1, lb2
 from .remote import rm, rm4, rm4mini, rm4pro, rmmini, rmminib, rmpro
 from .sensor import a1
 from .switch import bg1, mp1, sp1, sp2, sp2s, sp3, sp3s, sp4, sp4b
@@ -109,7 +109,7 @@ SUPPORTED_TYPES = {
     0x60C7: (lb1, "LB1", "Broadlink"),
     0x60C8: (lb1, "LB1", "Broadlink"),
     0x6112: (lb1, "LB1", "Broadlink"),
-    0xA4F4: (lb27r1, "LB27 R1", "Broadlink"),
+    0xA4F4: (lb2, "LB27 R1", "Broadlink"),
     0x2722: (S1C, "S2KIT", "Broadlink"),
     0x4EAD: (hysen, "HY02B05H", "Hysen"),
     0x4E4D: (dooya, "DT360E-45/20", "Dooya"),

--- a/broadlink/light.py
+++ b/broadlink/light.py
@@ -105,10 +105,10 @@ class lb1(Device):
         return state
 
 
-class lb27r1(Device):
-    """Controls a Broadlink LB27 R1."""
+class lb2(Device):
+    """Controls a Broadlink LB26/LB27."""
 
-    TYPE = "LB27R1"
+    TYPE = "LB2"
 
     @enum.unique
     class ColorMode(enum.IntEnum):


### PR DESCRIPTION
Rename lb27r1 class to lb2 before the release. This class can also control LB26 bulbs, which will appear here soon.