### PR TITLE
Add support for Broadlink SP4L-AU (0x757B)

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -45,6 +45,7 @@ SUPPORTED_TYPES = {
     0x756C: (sp4, "SP4M", "Broadlink"),
     0x756F: (sp4, "MCB1", "Broadlink"),
     0x7579: (sp4, "SP4L-EU", "Broadlink"),
+    0x757B: (sp4, "SP4L-AU", "Broadlink"),
     0x7583: (sp4, "SP mini 3", "Broadlink"),
     0x7587: (sp4, "SP4L-UK", "Broadlink"),
     0x7D11: (sp4, "SP mini 3", "Broadlink"),


### PR DESCRIPTION
From: https://github.com/home-assistant/core/issues/50021.

Thank you @mdemerson!