### PR TITLE
Remove local_ip_address option from hello()

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -148,14 +148,15 @@ def hello(
     host: str,
     port: int = DEFAULT_PORT,
     timeout: int = DEFAULT_TIMEOUT,
-    local_ip_address: str = None,
 ) -> Device:
     """Direct device discovery.
 
     Useful if the device is locked.
     """
     try:
-        return next(xdiscover(timeout, local_ip_address, host, port))
+        return next(
+            xdiscover(timeout=timeout, discover_ip_address=host, discover_ip_port=port)
+        )
     except StopIteration as err:
         raise e.NetworkTimeoutError(
             -4000,


### PR DESCRIPTION
This option doesn't make sense. When we specify a destination IP, we don't need to specify a local IP, as the OS will bind() automatically. Let's remove it before people start using it.