### PR TITLE
Add support for Broadlink SP4L-EU (0xA56C)

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -61,6 +61,7 @@ SUPPORTED_TYPES = {
         0x7587: ("SP4L-UK", "Broadlink"),
         0x7D11: ("SP mini 3", "Broadlink"),
         0xA56A: ("MCB1", "Broadlink"),
+        0xA56C: ("SP4L-EU", "Broadlink"),
         0xA589: ("SP4L-UK", "Broadlink"),
         0xA5D3: ("SP4L-EU", "Broadlink"),
     },


### PR DESCRIPTION
From: https://github.com/home-assistant/core/issues/50484

Thank you @Maximov-pcom-ha!