### PR TITLE
Add support for Broadlink RM mini 3 (0x27DC)

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -85,6 +85,7 @@ SUPPORTED_TYPES = {
         0x27D0: ("RM mini 3", "Broadlink"),
         0x27D1: ("RM mini 3", "Broadlink"),
         0x27D3: ("RM mini 3", "Broadlink"),
+        0x27DC: ("RM mini 3", "Broadlink"),
         0x27DE: ("RM mini 3", "Broadlink"),
     },
     rmpro: {


### PR DESCRIPTION
From: https://github.com/home-assistant/core/issues/50634.

Thank you @superman110!