### PR TITLE
Add ability to RF scan a specific frequency

### DIFF
--- a/cli/broadlink_cli
+++ b/cli/broadlink_cli
@@ -83,8 +83,8 @@ parser.add_argument("--switch", action="store_true", help="switch state from on 
 parser.add_argument("--send", action="store_true", help="send command")
 parser.add_argument("--sensors", action="store_true", help="check all sensors")
 parser.add_argument("--learn", action="store_true", help="learn command")
-parser.add_argument("--rfscanlearn", action="store_true", help="rf scan learning")
-parser.add_argument("--rflearn", nargs="?", type=float, const=433.92, metavar="FREQUENCY", help="rf learning on specified FREQUENCY, default: 433.92")
+parser.add_argument("--rflearn", action="store_true", help="rf scan learning")
+parser.add_argument("--frequency", type=float, help="specify radiofrequency for learning")
 parser.add_argument("--learnfile", help="save learned command to a specified file")
 parser.add_argument("--durations", action="store_true",
                     help="use durations in micro seconds instead of the Broadlink format")
@@ -196,35 +196,32 @@ if args.switch:
     else:
         dev.set_power(True)
         print('* Switch to ON *')
-if args.rfscanlearn or args.rflearn:
-    dev.sweep_frequency()
-    if args.rfscanlearn:
-        print("Learning RF Frequency, press and hold the button to learn...")
+if args.rflearn:
+    if args.frequency:
+        frequency = args.frequency
+    else:
+        dev.sweep_frequency()
+        print("Detecting radiofrequency, press and hold the button to learn...")
 
         start = time.time()
         while time.time() - start < TIMEOUT:
             time.sleep(1)
-            locked, frequency = dev.check_frequency_ex()
+            locked, frequency = dev.check_frequency()
             if locked:
                 break
-            print("Sweeping {}MHz...".format(frequency))
         else:
-            print("RF Frequency not found")
+            print("Radiofrequency not found")
             dev.cancel_sweep_frequency()
             exit(1)
-        frequency = dev.get_frequency()
 
-        print("Found RF Frequency {}MHz - 1 of 2!".format(frequency))
+        print("Radiofrequency detected: {}MHz".format(frequency))
         print("You can now let go of the button")
 
         input("Press enter to continue...")
 
-        dev.find_rf_packet()
-    else:
-        dev.find_rf_packet(args.rflearn)
-        print("Device tuned to {}MHz".format(dev.get_frequency()))
+    dev.find_rf_packet(frequency)
 
-    print("To complete learning, single press the button you want to learn")
+    print("Press the button again, now a short press.")
 
     start = time.time()
     while time.time() - start < TIMEOUT:
@@ -239,8 +236,7 @@ if args.rfscanlearn or args.rflearn:
         print("No data received...")
         exit(1)
 
-    if args.rfscanlearn:
-        print("Found RF Frequency - 2 of 2!")
+    print("Packet found!")
     learned = format_durations(to_microseconds(bytearray(data))) \
         if args.durations \
         else ''.join(format(x, '02x') for x in bytearray(data))

--- a/cli/broadlink_cli
+++ b/cli/broadlink_cli
@@ -128,7 +128,7 @@ if args.send:
     data = durations_to_broadlink(parse_durations(' '.join(args.data))) \
         if args.durations else bytearray.fromhex(''.join(args.data))
     dev.send_data(data)
-if args.learn or (args.learnfile and not args.rfscanlearn and not args.rflearn):
+if args.learn or (args.learnfile and not args.rflearn):
     dev.enter_learning()
     print("Learning...")
     start = time.time()

--- a/cli/broadlink_cli
+++ b/cli/broadlink_cli
@@ -199,6 +199,7 @@ if args.switch:
 if args.rflearn:
     if args.frequency:
         frequency = args.frequency
+        print("Press the button you want to learn, a short press...")
     else:
         dev.sweep_frequency()
         print("Detecting radiofrequency, press and hold the button to learn...")
@@ -219,9 +220,9 @@ if args.rflearn:
 
         input("Press enter to continue...")
 
-    dev.find_rf_packet(frequency)
+        print("Press the button again, now a short press.")
 
-    print("Press the button again, now a short press.")
+    dev.find_rf_packet(frequency)
 
     start = time.time()
     while time.time() - start < TIMEOUT:

--- a/cli/broadlink_cli
+++ b/cli/broadlink_cli
@@ -84,6 +84,7 @@ parser.add_argument("--send", action="store_true", help="send command")
 parser.add_argument("--sensors", action="store_true", help="check all sensors")
 parser.add_argument("--learn", action="store_true", help="learn command")
 parser.add_argument("--rfscanlearn", action="store_true", help="rf scan learning")
+parser.add_argument("--rflearn", nargs="?", type=float, const=433.92, metavar="FREQUENCY", help="rf learning on specified FREQUENCY, default: 433.92")
 parser.add_argument("--learnfile", help="save learned command to a specified file")
 parser.add_argument("--durations", action="store_true",
                     help="use durations in micro seconds instead of the Broadlink format")
@@ -127,7 +128,7 @@ if args.send:
     data = durations_to_broadlink(parse_durations(' '.join(args.data))) \
         if args.durations else bytearray.fromhex(''.join(args.data))
     dev.send_data(data)
-if args.learn or (args.learnfile and not args.rfscanlearn):
+if args.learn or (args.learnfile and not args.rfscanlearn and not args.rflearn):
     dev.enter_learning()
     print("Learning...")
     start = time.time()
@@ -195,28 +196,35 @@ if args.switch:
     else:
         dev.set_power(True)
         print('* Switch to ON *')
-if args.rfscanlearn:
+if args.rfscanlearn or args.rflearn:
     dev.sweep_frequency()
-    print("Learning RF Frequency, press and hold the button to learn...")
+    if args.rfscanlearn:
+        print("Learning RF Frequency, press and hold the button to learn...")
 
-    start = time.time()
-    while time.time() - start < TIMEOUT:
-        time.sleep(1)
-        if dev.check_frequency():
-            break
+        start = time.time()
+        while time.time() - start < TIMEOUT:
+            time.sleep(1)
+            locked, frequency = dev.check_frequency_ex()
+            if locked:
+                break
+            print("Sweeping {}MHz...".format(frequency))
+        else:
+            print("RF Frequency not found")
+            dev.cancel_sweep_frequency()
+            exit(1)
+        frequency = dev.get_frequency()
+
+        print("Found RF Frequency {}MHz - 1 of 2!".format(frequency))
+        print("You can now let go of the button")
+
+        input("Press enter to continue...")
+
+        dev.find_rf_packet()
     else:
-        print("RF Frequency not found")
-        dev.cancel_sweep_frequency()
-        exit(1)
-
-    print("Found RF Frequency - 1 of 2!")
-    print("You can now let go of the button")
-
-    input("Press enter to continue...")
+        dev.find_rf_packet(args.rflearn)
+        print("Device tuned to {}MHz".format(dev.get_frequency()))
 
     print("To complete learning, single press the button you want to learn")
-
-    dev.find_rf_packet()
 
     start = time.time()
     while time.time() - start < TIMEOUT:
@@ -231,7 +239,8 @@ if args.rfscanlearn:
         print("No data received...")
         exit(1)
 
-    print("Found RF Frequency - 2 of 2!")
+    if args.rfscanlearn:
+        print("Found RF Frequency - 2 of 2!")
     learned = format_durations(to_microseconds(bytearray(data))) \
         if args.durations \
         else ''.join(format(x, '02x') for x in bytearray(data))


### PR DESCRIPTION
This adds an optional parameter to find_rf_packet(), along with a
corresponding --rflearn parameter (defaulting to 433.92) to
broadlink_cli that specifies the frequency to tune to, rather than
requiring the frequency be found via sweeping. This is almost mandatory
for certain types of remotes that do not repeat their signals while the
button is held, and saves significant time when the frequency is known
in advance or when many buttons are to be captured in a row.

Fixes https://github.com/mjg59/python-broadlink/issues/459