### PR TITLE
modify support 0x4EF7 mp1, which MP1 can return the energy state

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -95,7 +95,7 @@ SUPPORTED_TYPES = {
     0x653C: (rm4pro, "RM4 pro", "Broadlink"),
     0x2714: (a1, "e-Sensor", "Broadlink"),
     0x4EB5: (mp1, "MP1-1K4S", "Broadlink"),
-    0x4EF7: (mp1, "MP1-1K4S", "Broadlink (OEM)"),
+    0x4EF7: (mp1m, "MP1-1K4S", "Broadlink (OEM)"),
     0x4F1B: (mp1, "MP1-1K3S2U", "Broadlink (OEM)"),
     0x4F65: (mp1, "MP1-1K3S2U", "Broadlink"),
     0x5043: (lb1, "SB800TD", "Broadlink (OEM)"),

--- a/broadlink/switch.py
+++ b/broadlink/switch.py
@@ -63,6 +63,18 @@ class mp1(device):
         data["s4"] = bool(state & 0x08)
         return data
 
+class mp1m(mp1):
+    """Controls a Broadlink MP1M."""
+
+    TYPE = "MP1M"
+
+    def get_energy(self) -> float:
+        """Return the energy state of the device."""
+        packet = bytearray([8, 0, 254, 1, 5, 1, 0, 0, 0, 45])
+        response = self.send_packet(0x6A, packet)
+        check_error(response[0x22:0x24])
+        payload = self.decrypt(response[0x38:])
+        return int((payload[0x07] + payload[0x06] / 100) * 100) + payload[0x05] / 100
 
 class bg1(device):
     """Controls a BG Electrical smart outlet."""


### PR DESCRIPTION
0x4EF7: (mp1m, "MP1-1K4S", "Broadlink (OEM)")
This type MP1 can return the energy state.