### PR TITLE
Fix steps in bulleted list

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ Example use
 Setup a new device on your local wireless network:
 
 1. Put the device into AP Mode
-  1. Long press the reset button until the blue LED is blinking quickly.
-  2. Long press again until blue LED is blinking slowly.
-  3. Manually connect to the WiFi SSID named BroadlinkProv.
+    1. Long press the reset button until the blue LED is blinking quickly.
+    2. Long press again until blue LED is blinking slowly.
+    3. Manually connect to the WiFi SSID named BroadlinkProv.
 2. Run setup() and provide your ssid, network password (if secured), and set the security mode
-  1. Security mode options are (0 = none, 1 = WEP, 2 = WPA1, 3 = WPA2, 4 = WPA1/2)
+    1. Security mode options are (0 = none, 1 = WEP, 2 = WPA1, 3 = WPA2, 4 = WPA1/2)
 ```
 import broadlink
 


### PR DESCRIPTION
Steps were showing up as a flat 1..6 list because GitHub wasn't picking up the 2-space indent correctly. Switching to 4-space fixes it.