### PR TITLE
Bump version to 0.18.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 from setuptools import setup, find_packages
 
 
-version = '0.17.0'
+version = '0.18.0'
 
 setup(
     name="broadlink",


### PR DESCRIPTION
## Breaking changes

- Rename broadlink.device.device to broadlink.device.Device.
- Change crc16() to CRC16.calculate()
- Change hysen.TYPE from "Hysen heating controller" to "HYS".
- Change hysen.model from "HY02B05H" to "HY02/HY03".
- Remove local_ip_address option from broadlink.hello()
- Refactor SUPPORTED_TYPES.

### Before

```python3
SUPPORTED_TYPES = {
    0x0000: (sp1, "SP1", "Broadlink"),
    0x2717: (sp2, "NEO", "Ankuoo"),
    0x2719: (sp2, "SP2-compatible", "Honeywell"),
    0x271A: (sp2, "SP2-compatible", "Honeywell"),
    ...
}
```

### After

```python3
SUPPORTED_TYPES = {
    sp1: {
        0x0000: ("SP1", "Broadlink"),
    },
    sp2: {
        0x2717: ("NEO", "Ankuoo"),
        0x2719: ("SP2-compatible", "Honeywell"),
        0x271A: ("SP2-compatible", "Honeywell"),
        ...
    }
    ...
}
```

## Changelog:

- Change the type and model of the hysen class (#627)
- Add pull request template (#626)
- Improve README.md (#625)
- Fix indentation of README.md (#624)
- Add support for Broadlink SCB1E (0xA56B) (#623)
- Fix flake8 tests (#622)
- Add support for Clas Ohlson SL-2 E14 (0x6065) (#600)
- Add support for Broadlink RM mini 3 (0x27DC) (#594)
- Add support for Broadlink SP4L-EU (0xA56C) (#593)
- Refactor SUPPORTED_TYPES (#592)
- Remove local_ip_address option from hello() (#591)
- Add support for Broadlink SP4L-AU (0x757B) (#590)
- Add support for Broadlink RM mini 3 (0x6507) (#589)
- Rename the lb27r1 class to lb2 (#586)
- Improve code quality (#585)
- Move constants to const.py (#584)
- Add support for Broadlink SP4L-EU (0xA5D3) (#582)
- Add support for Broadlink SP4L-CN (0x7568) (#577)
- Use the absolute position to read the lock status (#575)
- Improve code quality (#572)
- Use CamelCase for the Device class (#570)
- Raise exceptions explicitly (#569)
- Add support for Broadlink RM4C pro (0x6184) (#568)
- Segregate CRC16.get_table() from CRC16.calculate() (#567)
- Encapsulate crc16() to avoid global (#566)
- Improve CRC-16 function (#565)
- Make better use of namespaces (#564)
- Add support for Broadlink LB27 R1 (0xA4F4) (#557)
- Add support for Broadlink SP4L-UK (0x7587) (#561)
- Add support for Broadlink SCB2 (0x6494) (#558)
- Improve the CLI (#555)
- Add a TROUBLESHOOTING doc with WiFi password notes (#563)
