### PR TITLE
Fix flake8 tests

### DIFF
--- a/.github/workflows/flake8.yaml
+++ b/.github/workflows/flake8.yaml
@@ -21,7 +21,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 wemake-python-styleguide
+        pip install wheel
+        pip install flake8 flake8-quotes
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |


### PR DESCRIPTION
## Context

Flake8 tests started giving false positives recently. We are getting the same error for all PRs:

```
flake8: error: unrecognized arguments: --inline-quotes double
```
The flake8-quotes dependency is not being installed correctly before testing, hence the error. This module requires the wheel installed first.

## Proposed change

Install the wheel, remove wemake-python-styleguide dependency and install flake8-quotes explicitly in the Flake8 tests.