### PR TITLE
Change the type and model of the hysen class

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -152,7 +152,7 @@ SUPPORTED_TYPES = {
         0x2722: ("S2KIT", "Broadlink"),
     },
     hysen: {
-        0x4EAD: ("HY02B05H", "Hysen"),
+        0x4EAD: ("HY02/HY03", "Hysen"),
     },
     dooya: {
         0x4E4D: ("DT360E-45/20", "Dooya"),

--- a/broadlink/climate.py
+++ b/broadlink/climate.py
@@ -7,9 +7,17 @@ from .helpers import CRC16
 
 
 class hysen(Device):
-    """Controls a Hysen HVAC."""
+    """Controls a Hysen heating thermostat.
 
-    TYPE = "Hysen heating controller"
+    This device is manufactured by Hysen and sold under different
+    brands, including Floureon, Beca Energy, Beok and Decdeal.
+
+    Supported models:
+    - HY02B05H
+    - HY03WE
+    """
+
+    TYPE = "HYS"
 
     def send_request(self, request: t.Sequence[int]) -> bytes:
         """Send a request to the device."""


### PR DESCRIPTION
## Context

The current type of the hysen class is too big, [check this out](https://github.com/home-assistant/core/blob/a4a1f803264d96bd4b2154c1e8e74f8347766acf/homeassistant/components/broadlink/const.py#L9-L14). Also, there are other models that are supported by this class, like "HY03WE", but it always shows "HY02B05H".

## Proposed change

Change hysen.TYPE from "Hysen heating controller" to "HYS". Change hysen.model from to "HY02B05H" to "HY02/HY03".