### PR TITLE
Add support for Broadlink MP1 with power meter

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -12,7 +12,7 @@ from .device import Device, ping, scan
 from .light import lb1, lb2
 from .remote import rm, rm4, rm4mini, rm4pro, rmmini, rmminib, rmpro
 from .sensor import a1
-from .switch import bg1, mp1, sp1, sp2, sp2s, sp3, sp3s, sp4, sp4b
+from .switch import bg1, mp1, mp1s, sp1, sp2, sp2s, sp3, sp3s, sp4, sp4b
 
 SUPPORTED_TYPES = {
     sp1: {
@@ -133,9 +133,11 @@ SUPPORTED_TYPES = {
     },
     mp1: {
         0x4EB5: ("MP1-1K4S", "Broadlink"),
-        0x4EF7: ("MP1-1K4S", "Broadlink (OEM)"),
         0x4F1B: ("MP1-1K3S2U", "Broadlink (OEM)"),
         0x4F65: ("MP1-1K3S2U", "Broadlink"),
+    },
+    mp1s: {
+        0x4EF7: ("MP1-1K4S", "Broadlink (OEM)"),
     },
     lb1: {
         0x5043: ("SB800TD", "Broadlink (OEM)"),

--- a/broadlink/switch.py
+++ b/broadlink/switch.py
@@ -360,3 +360,18 @@ class mp1(Device):
             "s3": bool(data & 4),
             "s4": bool(data & 8),
         }
+
+
+class mp1s(mp1):
+    """Controls a Broadlink MP1S."""
+
+    TYPE = "MP1S"
+
+    def get_energy(self) -> float:
+        """Return the power consumption in W."""
+        packet = bytearray([8, 0, 254, 1, 5, 1, 0, 0, 0, 45])
+        response = self.send_packet(0x6A, packet)
+        e.check_error(response[0x22:0x24])
+        payload = self.decrypt(response[0x38:])
+        energy = payload[0x7:0x4:-1].hex()
+        return int(energy) / 100


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please fill the template to help maintainers processing your PR.

  Don't forget to create the PR against the correct branch:
  - new product id -> new_product_ids
  - anything else -> dev
-->
## Breaking change
Change MP1-1K4S 0x4EF7's class to mp1s.

## Context
<!--
  Summarize the motivation and context of the change.
  Which issue are you dealing with?
-->
Some MP1 devices have power meter. We are not supporting this sensor, currently.

## Proposed change
<!--
  Describe the change. How are you fixing the issue?
-->
Create mp1s class, a subclass of mp1 with get_energy() method. Refer devices to this class, when applicable.

## Credits

From: https://github.com/mjg59/python-broadlink/pull/615. Thanks @vaughan-zeng!


## Type of change
<!--
  What type of change does your PR introduce?
  Please, check only 1 box!
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New device
- [ ] New product id (the device is already supported with a different id)
- [ ] New feature (which adds functionality to an existing device)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information
<!--
  Link docs and related issues, when applicable.
-->

- This PR fixes issue: fixes https://github.com/mjg59/python-broadlink/issues/474
- This PR is related to: https://github.com/mjg59/python-broadlink/pull/615
- Link to documentation pull request: 

## Checklist
<!--
  Please do your best to check these boxes.
-->

- [x] The code change is tested and works locally.
- [x] The code has been formatted using Black.
- [x] The code follows the [Zen of Python](https://www.python.org/dev/peps/pep-0020/).
- [x] I am creating the Pull Request against the correct branch.
- [ ] Documentation added/updated.
