### PR TITLE
Add support for Broadlink LB26 R1 (0x644E)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A Python module and CLI for controlling Broadlink devices locally. The following
 - **Power strips**: MP1-1K3S2U, MP1-1K4S, MP2
 - **Environment sensors**: A1
 - **Alarm kits**: S1C, S2KIT
-- **Light bulbs**: LB1, LB2, SB800TD
+- **Light bulbs**: LB1, LB26 R1, LB27 R1, SB800TD
 - **Curtain motors**: Dooya DT360E-45/20
 - **Thermostats**: Hysen HY02B05H
 

--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -146,6 +146,7 @@ SUPPORTED_TYPES = {
         0x6112: ("LB1", "Broadlink"),
     },
     lb2: {
+        0x644E: ("LB26 R1", "Broadlink"),
         0xA4F4: ("LB27 R1", "Broadlink"),
     },
     S1C: {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please fill the template to help maintainers processing your PR.

  Don't forget to create the PR against the correct branch:
  - new product id -> new_product_ids
  - anything else -> dev
-->
## Context
<!--
  Summarize the motivation and context of the change.
  Which issue are you dealing with?
-->
A [new LB2](https://github.com/mjg59/python-broadlink/issues/635) was found. It works like the others. Thanks  @jmacri922!

## Proposed change
<!--
  Describe the change. How are you fixing the issue?
-->
Add support for Broadlink LB26 R1 (0x644E).

## Type of change
<!--
  What type of change does your PR introduce?
  Please, check only 1 box!
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New device
- [x] New product id (the device is already supported with a different id)
- [ ] New feature (which adds functionality to an existing device)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information
<!--
  Link docs and related issues, when applicable.
-->

- This PR fixes issue: fixes https://github.com/mjg59/python-broadlink/issues/635
- This PR is related to: 
- Link to documentation pull request: 

## Checklist
<!--
  Please do your best to check these boxes.
-->

- [ ] The code change is tested and works locally.
- [x] The code has been formatted using Black.
- [x] The code follows the [Zen of Python](https://www.python.org/dev/peps/pep-0020/).
- [x] I am creating the Pull Request against the correct branch.
- [x] Documentation added/updated.
