### PR TITLE
Add missing device codes for LB27 R1 Smart Bulbs

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -147,6 +147,8 @@ SUPPORTED_TYPES = {
     },
     lb2: {
         0xA4F4: ("LB27 R1", "Broadlink"),
+        0xA5F7: ("LB27 R1", "Broadlink"),
+        0x644C: ("LB27 R1", "Broadlink"),        
     },
     S1C: {
         0x2722: ("S2KIT", "Broadlink"),


### PR DESCRIPTION
## Context
Add two missing product ids for LB27 R1 Smart Bulbs


## Proposed change
Adding in the missing codes.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New device
- [x] New product id (the device is already supported with a different id)
- [ ] New feature (which adds functionality to an existing device)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information
- This PR fixes issue: fixes #639
- This PR is related to: 
- Link to documentation pull request: 

## Checklist
- [x] The code change is tested and works locally.
- [x] The code has been formatted using Black.
- [x] The code follows the [Zen of Python](https://www.python.org/dev/peps/pep-0020/).
- [x] I am creating the Pull Request against the correct branch.
- [ ] Documentation added/updated.
