### PR TITLE
Move 0x644C and 0x644E to the LB1 class

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -145,12 +145,12 @@ SUPPORTED_TYPES = {
         0x60C7: ("LB1", "Broadlink"),
         0x60C8: ("LB1", "Broadlink"),
         0x6112: ("LB1", "Broadlink"),
+        0x644C: ("LB27 R1", "Broadlink"),        
+        0x644E: ("LB26 R1", "Broadlink"),
     },
     lb2: {
-        0x644E: ("LB26 R1", "Broadlink"),
         0xA4F4: ("LB27 R1", "Broadlink"),
         0xA5F7: ("LB27 R1", "Broadlink"),
-        0x644C: ("LB27 R1", "Broadlink"),        
     },
     S1C: {
         0x2722: ("S2KIT", "Broadlink"),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please fill the template to help maintainers processing your PR.

  Don't forget to create the PR against the correct branch:
  - new product id -> new_product_ids
  - anything else -> dev
-->
## Context
<!--
  Summarize the motivation and context of the change.
  Which issue are you dealing with?
-->
We recently added these two product ids (0x644C and 0X644E) to the wrong class. They work the same as LB1. 

## Proposed change
<!--
  Describe the change. How are you fixing the issue?
-->
Move 0x644C and 0x644E to the LB1 class.

## Type of change
<!--
  What type of change does your PR introduce?
  Please, check only 1 box!
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New device
- [ ] New product id (the device is already supported with a different id)
- [ ] New feature (which adds functionality to an existing device)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information
<!--
  Link docs and related issues, when applicable.
-->

- This PR fixes issue: fixes #
- This PR is related to:
  - https://github.com/mjg59/python-broadlink/pull/636
  - https://github.com/mjg59/python-broadlink/pull/644
- Link to documentation pull request: 

## Checklist
<!--
  Please do your best to check these boxes.
-->

- [ ] The code change is tested and works locally.
- [x] The code has been formatted using Black.
- [x] The code follows the [Zen of Python](https://www.python.org/dev/peps/pep-0020/).
- [x] I am creating the Pull Request against the correct branch.
- [ ] Documentation added/updated.
