### PR TITLE
Merge new product ids into master

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Python module and CLI for controlling Broadlink devices locally. The following devices are supported:
 
-- **Universal remotes**: RM home, RM mini 3, RM plus, RM pro, RM pro+, RM4 mini, RM4 pro, RM4C mini, RM4S
+- **Universal remotes**: RM home, RM mini 3, RM plus, RM pro, RM pro+, RM4 mini, RM4 pro, RM4C mini, RM4S, RM4 TV mate
 - **Smart plugs**: SP mini, SP mini 3, SP mini+, SP1, SP2, SP2-BR, SP2-CL, SP2-IN, SP2-UK, SP3, SP3-EU, SP3S-EU, SP3S-US, SP4L-AU, SP4L-EU, SP4L-UK, SP4M, SP4M-US, Ankuoo NEO, Ankuoo NEO PRO, Efergy Ego, BG AHC/U-01
 - **Switches**: MCB1, SC1, SCB1E, SCB2
 - **Outlets**: BG 800, BG 900

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A Python module and CLI for controlling Broadlink devices locally. The following
 - **Power strips**: MP1-1K3S2U, MP1-1K4S, MP2
 - **Environment sensors**: A1
 - **Alarm kits**: S1C, S2KIT
-- **Light bulbs**: LB1, LB2, SB800TD
+- **Light bulbs**: LB1, LB26 R1, LB27 R1, SB800TD
 - **Curtain motors**: Dooya DT360E-45/20
 - **Thermostats**: Hysen HY02B05H
 

--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -111,6 +111,7 @@ SUPPORTED_TYPES = {
     },
     rm4mini: {
         0x51DA: ("RM4 mini", "Broadlink"),
+        0x5209: ("RM4 TV mate", "Broadlink"),
         0x6070: ("RM4C mini", "Broadlink"),
         0x610E: ("RM4 mini", "Broadlink"),
         0x610F: ("RM4C mini", "Broadlink"),

--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -148,6 +148,8 @@ SUPPORTED_TYPES = {
     lb2: {
         0x644E: ("LB26 R1", "Broadlink"),
         0xA4F4: ("LB27 R1", "Broadlink"),
+        0xA5F7: ("LB27 R1", "Broadlink"),
+        0x644C: ("LB27 R1", "Broadlink"),        
     },
     S1C: {
         0x2722: ("S2KIT", "Broadlink"),

--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -146,6 +146,7 @@ SUPPORTED_TYPES = {
         0x6112: ("LB1", "Broadlink"),
     },
     lb2: {
+        0x644E: ("LB26 R1", "Broadlink"),
         0xA4F4: ("LB27 R1", "Broadlink"),
     },
     S1C: {

--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -146,12 +146,12 @@ SUPPORTED_TYPES = {
         0x60C7: ("LB1", "Broadlink"),
         0x60C8: ("LB1", "Broadlink"),
         0x6112: ("LB1", "Broadlink"),
+        0x644C: ("LB27 R1", "Broadlink"),        
+        0x644E: ("LB26 R1", "Broadlink"),
     },
     lb2: {
-        0x644E: ("LB26 R1", "Broadlink"),
         0xA4F4: ("LB27 R1", "Broadlink"),
         0xA5F7: ("LB27 R1", "Broadlink"),
-        0x644C: ("LB27 R1", "Broadlink"),        
     },
     S1C: {
         0x2722: ("S2KIT", "Broadlink"),

--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -122,6 +122,7 @@ SUPPORTED_TYPES = {
         0x653A: ("RM4 mini", "Broadlink"),
     },
     rm4pro: {
+        0x5213: ("RM4 pro", "Broadlink"),
         0x6026: ("RM4 pro", "Broadlink"),
         0x6184: ("RM4C pro", "Broadlink"),
         0x61A2: ("RM4 pro", "Broadlink"),


### PR DESCRIPTION
We found new product ids: LB26 R1 (0x644E), LB27 R1 (0x644C), LB27 R1 (0xA5F7), RM4 pro (0x5213) e RM TV mate (0x5209). This update brings them to the master branch.
