### PR TITLE
Bump version to 0.18.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 from setuptools import setup, find_packages
 
 
-version = '0.18.0'
+version = '0.18.1'
 
 setup(
     name="broadlink",


### PR DESCRIPTION
## Changelog:

- Add new product ids:  LB26 R1 (0x644E), LB27 R1 (0x644C), LB27 R1 (0xA5F7), RM4 pro (0x5213) e RM TV mate (0x5209) #667