### PR TITLE
Add support for RM4C mini (0x520D)

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -115,6 +115,7 @@ SUPPORTED_TYPES = {
         0x51DA: ("RM4 mini", "Broadlink"),
         0x5209: ("RM4 TV mate", "Broadlink"),
         0x520C: ("RM4 mini", "Broadlink"),
+        0x520D: ("RM4C mini", "Broadlink"),
         0x5212: ("RM4 TV mate", "Broadlink"),
         0x5216: ("RM4 mini", "Broadlink"),
         0x6070: ("RM4C mini", "Broadlink"),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please fill the template to help maintainers processing your PR.

  Don't forget to create the PR against the correct branch:
  - new product id -> new_product_ids
  - anything else -> dev
-->
## Context
<!--
  Summarize the motivation and context of the change.
  Which issue are you dealing with?
-->
I added new device RM4C mini buyed on Aliexpress with id 0x520D.
The firmware version is v52079
It support WIFI and bluetooth both

I tested the new device editing the python-broadlink library, in my home assistant instante.
After the file edit I added the device to the home assistant official integration. After I used smartIR to send command my Mitsubishi HVAC.

## Proposed change
<!--
  Describe the change. How are you fixing the issue?
-->


## Type of change
<!--
  What type of change does your PR introduce?
  Please, check only 1 box!
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New device
- [x] New product id (the device is already supported with a different id)
- [ ] New feature (which adds functionality to an existing device)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information
<!--
  Link docs and related issues, when applicable.
-->

- This PR fixes issue: fixes #689
- This PR is related to: 
- Link to documentation pull request: 

## Checklist
<!--
  Please do your best to check these boxes.
-->

- [x] The code change is tested and works locally.
- [ ] The code has been formatted using Black.
- [ ] The code follows the [Zen of Python](https://www.python.org/dev/peps/pep-0020/).
- [x] I am creating the Pull Request against the correct branch.
- [ ] Documentation added/updated.
