### PR TITLE
Add support for Broadlink LB1 bulb (0x644B)

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -153,9 +153,9 @@ SUPPORTED_TYPES = {
         0x60C7: ("LB1", "Broadlink"),
         0x60C8: ("LB1", "Broadlink"),
         0x6112: ("LB1", "Broadlink"),
+        0x644B: ("LB1", "Broadlink"),
         0x644C: ("LB27 R1", "Broadlink"),        
         0x644E: ("LB26 R1", "Broadlink"),
-        0x644B: ("LB1", "Broadlink"),
     },
     lb2: {
         0xA4F4: ("LB27 R1", "Broadlink"),

--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -155,6 +155,7 @@ SUPPORTED_TYPES = {
         0x6112: ("LB1", "Broadlink"),
         0x644C: ("LB27 R1", "Broadlink"),        
         0x644E: ("LB26 R1", "Broadlink"),
+        0x644B: ("LB1", "Broadlink"),
     },
     lb2: {
         0xA4F4: ("LB27 R1", "Broadlink"),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please fill the template to help maintainers processing your PR.

  Don't forget to create the PR against the correct branch:
  - new product id -> new_product_ids
  - anything else -> dev
-->
## Context
<!--
  Summarize the motivation and context of the change.
  Which issue are you dealing with?
-->
Home Assistant returning the error "Unsupported device: 0x644b".


## Proposed change
<!--
  Describe the change. How are you fixing the issue?
-->
Adding a new type for the LB1 bulb (0x644B).


## Type of change
<!--
  What type of change does your PR introduce?
  Please, check only 1 box!
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New device
- [x] New product id (the device is already supported with a different id)
- [ ] New feature (which adds functionality to an existing device)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information
<!--
  Link docs and related issues, when applicable.
-->

- This PR fixes issue: N/A
- This PR is related to: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Please do your best to check these boxes.
-->

- [x] The code change is tested and works locally.
- [x] The code has been formatted using Black.
- [x] The code follows the [Zen of Python](https://www.python.org/dev/peps/pep-0020/).
- [x] I am creating the Pull Request against the correct branch.
- [ ] Documentation added/updated.
