### PR TITLE
Add 0x6488 (Broadlink LB27 C1) bulb support.

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -155,6 +155,7 @@ SUPPORTED_TYPES = {
         0x6112: ("LB1", "Broadlink"),
         0x644C: ("LB27 R1", "Broadlink"),        
         0x644E: ("LB26 R1", "Broadlink"),
+        0x6488: ("LB27 C1", "Broadlink"),
     },
     lb2: {
         0xA4F4: ("LB27 R1", "Broadlink"),


### PR DESCRIPTION
Add 0x6488 (Broadlink LB27 C1) bulb support. This is a white-only bulb with temperature and dim adjustment options.