### PR TITLE
Expose durations beyond the CLI

### DIFF
--- a/broadlink/remote.py
+++ b/broadlink/remote.py
@@ -9,6 +9,10 @@ IR_TOKEN = 0x26
 
 
 def durations_to_ir_data(durations) -> None:
+    """Convert a microsecond duration sequence into a Broadlink IR packet
+
+    This can then be passed into send_data.
+    """
     result = bytearray()
     result.append(IR_TOKEN)
     result.append(0)
@@ -24,6 +28,10 @@ def durations_to_ir_data(durations) -> None:
 
 
 def data_to_durations(bytes):
+    """Parse a Broadlink packet into a microsecond duration sequence
+
+    Supports both IR and RF.
+    """
     result = []
     # XXX: Should check IR/RF token, repeat and length bytes.
     index = 4

--- a/cli/broadlink_cli
+++ b/cli/broadlink_cli
@@ -110,17 +110,17 @@ if args.learn or (args.learnfile and not args.rfscanlearn):
         print("No data received...")
         exit(1)
 
-    learned = format_durations(data_to_durations(bytearray(data))) \
+    learned_str = format_durations(data_to_durations(bytearray(data))) \
         if args.durations \
         else ''.join(format(x, '02x') for x in bytearray(data))
     if args.learn:
-        print(learned)
+        print(learned_str)
         decode_hex = codecs.getdecoder("hex_codec")
-        print("Base64: " + str(base64.b64encode(decode_hex(learned)[0])))
+        print("Base64: " + base64.b64encode(data).decode('ascii'))
     if args.learnfile:
         print("Saving to {}".format(args.learnfile))
         with open(args.learnfile, "w") as text_file:
-            text_file.write(learned)
+            text_file.write(learned_str)
 if args.check:
     if dev.check_power():
         print('* ON *')

--- a/cli/broadlink_cli
+++ b/cli/broadlink_cli
@@ -7,46 +7,13 @@ import time
 import broadlink
 from broadlink.const import DEFAULT_PORT
 from broadlink.exceptions import ReadError, StorageError
+from broadlink.remote import data_to_durations, durations_to_ir_data
 
-TICK = 32.84
 TIMEOUT = 30
-IR_TOKEN = 0x26
 
 
 def auto_int(x):
     return int(x, 0)
-
-
-def to_microseconds(bytes):
-    result = []
-    #  print bytes[0] # 0x26 = 38for IR
-    index = 4
-    while index < len(bytes):
-        chunk = bytes[index]
-        index += 1
-        if chunk == 0:
-            chunk = bytes[index]
-            chunk = 256 * chunk + bytes[index + 1]
-            index += 2
-        result.append(int(round(chunk * TICK)))
-        if chunk == 0x0d05:
-            break
-    return result
-
-
-def durations_to_broadlink(durations):
-    result = bytearray()
-    result.append(IR_TOKEN)
-    result.append(0)
-    result.append(len(durations) % 256)
-    result.append(len(durations) / 256)
-    for dur in durations:
-        num = int(round(dur / TICK))
-        if num > 255:
-            result.append(0)
-            result.append(num / 256)
-        result.append(num % 256)
-    return result
 
 
 def format_durations(data):
@@ -111,7 +78,7 @@ if args.joinwifi:
 
 if args.convert:
     data = bytearray.fromhex(''.join(args.data))
-    durations = to_microseconds(data)
+    durations = data_to_durations(data)
     print(format_durations(durations))
 if args.temperature:
     print(dev.check_temperature())
@@ -124,7 +91,7 @@ if args.sensors:
     for key in data:
         print("{} {}".format(key, data[key]))
 if args.send:
-    data = durations_to_broadlink(parse_durations(' '.join(args.data))) \
+    data = durations_to_ir_data(parse_durations(' '.join(args.data))) \
         if args.durations else bytearray.fromhex(''.join(args.data))
     dev.send_data(data)
 if args.learn or (args.learnfile and not args.rfscanlearn):
@@ -143,7 +110,7 @@ if args.learn or (args.learnfile and not args.rfscanlearn):
         print("No data received...")
         exit(1)
 
-    learned = format_durations(to_microseconds(bytearray(data))) \
+    learned = format_durations(data_to_durations(bytearray(data))) \
         if args.durations \
         else ''.join(format(x, '02x') for x in bytearray(data))
     if args.learn:
@@ -232,7 +199,7 @@ if args.rfscanlearn:
         exit(1)
 
     print("Found RF Frequency - 2 of 2!")
-    learned = format_durations(to_microseconds(bytearray(data))) \
+    learned = format_durations(data_to_durations(bytearray(data))) \
         if args.durations \
         else ''.join(format(x, '02x') for x in bytearray(data))
     if args.learnfile is None:


### PR DESCRIPTION
## Context
Broadlink's IR/RF message protocol is well-understood, but translation between it and the standard microsecond duration format usable in other IR contexts is only accessible via broadlink_cli.

## Proposed change
Move the two duration<->Broadlink functions from broadlink_cli to broadlink.remote, where they can be used by applications consuming the library.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New device
- [ ] New product id (the device is already supported with a different id)
- [ ] New feature (which adds functionality to an existing device)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Checklist

- [x] The code change is tested and works locally.
- [x] The code has been formatted using Black.
- [x] The code follows the [Zen of Python](https://www.python.org/dev/peps/pep-0020/).
- [x] I am creating the Pull Request against the correct branch.
- [ ] Documentation added/updated.
