### PR TITLE
Add support for Broadlink RM mini 3 (0x27B7)

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -83,6 +83,7 @@ SUPPORTED_TYPES = {
     rmmini: {
         0x2737: ("RM mini 3", "Broadlink"),
         0x278F: ("RM mini", "Broadlink"),
+        0x27B7: ("RM mini 3", "Broadlink"),
         0x27C2: ("RM mini 3", "Broadlink"),
         0x27C7: ("RM mini 3", "Broadlink"),
         0x27CC: ("RM mini 3", "Broadlink"),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please fill the template to help maintainers processing your PR.

  Don't forget to create the PR against the correct branch:
  - new product id -> new_product_ids
  - anything else -> dev
-->
## Proposed change
<!--
  Describe the change. How are you fixing the issue?
-->
Add support for Broadlink RM mini 3.

## Type of change
<!--
  What type of change does your PR introduce?
  Please, check only 1 box!
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New device
- [x] New product id (the device is already supported with a different id)
- [ ] New feature (which adds functionality to an existing device)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information
<!--
  Link docs and related issues, when applicable.
-->

- This PR fixes issue: fixes https://github.com/home-assistant/core/issues/88322
- This PR is related to: 
- Link to documentation pull request: 

## Checklist
<!--
  Please do your best to check these boxes.
-->

- [ ] The code change is tested and works locally.
- [ ] The code has been formatted using Black.
- [ ] The code follows the [Zen of Python](https://www.python.org/dev/peps/pep-0020/).
- [x] I am creating the Pull Request against the correct branch.
- [ ] Documentation added/updated.
