### PR TITLE
Add support for Luceco/BG Electrical Smart Bulb (0x606d)

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -156,6 +156,7 @@ SUPPORTED_TYPES = {
     lb1: {
         0x5043: ("SB800TD", "Broadlink (OEM)"),
         0x504E: ("LB1", "Broadlink"),
+        0x606D: ("SLA2?RGB9W81", "Luceco/BG Electrical"),
         0x606E: ("SB500TD", "Broadlink (OEM)"),
         0x60C7: ("LB1", "Broadlink"),
         0x60C8: ("LB1", "Broadlink"),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please fill the template to help maintainers processing your PR.

  Don't forget to create the PR against the correct branch:
  - new product id -> new_product_ids
  - anything else -> dev
-->
## Context
<!--
  Summarize the motivation and context of the change.
  Which issue are you dealing with?
-->
The Luceco Smart Bulbs https://www.bg-home.uk/a60-globe appear to be white labelled Broadlink bulbs. Adding the ID makes them recognisable and controllable from this library.

The product's catalogue numbers: SLA22RGB9W81 or SLA27RGB9W81, are printed on the side of the device along with the Luceco brand. The bulbs are normally controlled by the BG-Home app and need to be removed from the app to be unlocked. 

## Proposed change
<!--
  Describe the change. How are you fixing the issue?
-->
Add product ID for compatible bulb.


## Type of change
<!--
  What type of change does your PR introduce?
  Please, check only 1 box!
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New device
- [x] New product id (the device is already supported with a different id)
- [ ] New feature (which adds functionality to an existing device)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information
<!--
  Link docs and related issues, when applicable.
-->

- This PR fixes issue: fixes #765 

Adding the ID to the LB1 supported types gives access to this device. The following works as expected:

```
import broadlink
broadlink.discover()
device = broadlink.hello('192.168.0.56')
device.auth()
device.get_state()

device.set_state(pwr=0)
device.set_state(pwr=1)
device.set_state(bulb_colormode=0, red=255, green=0, blue=0, brightness=255)
device.set_state(bulb_colormode=1,brightness=255, colortemp=2700)
device.set_state(bulb_colormode=1,brightness=255, colortemp=6500)

```

No updates to documentation, this appears to be just another white label ID rather than a new device.

## Checklist
<!--
  Please do your best to check these boxes.
-->

- [x] The code change is tested and works locally.
- [x] The code has been formatted using Black.
- [x] The code follows the [Zen of Python](https://www.python.org/dev/peps/pep-0020/).
- [x] I am creating the Pull Request against the correct branch.
- [ ] Documentation added/updated.
