### PR TITLE
Thermostat: get the 1st decimal place

### DIFF
--- a/broadlink/climate.py
+++ b/broadlink/climate.py
@@ -43,15 +43,28 @@ class hysen(Device):
 
         return payload[0x02:p_len]
 
+    def _room_or_ext_temp_logic(self, payload, base_index):
+        base_temp = payload[base_index] / 2.0
+        add_offset = (payload[4] >> 3) & 1  # should offset be added?
+        offset_raw_value = (payload[17] >> 4) & 3  # offset value
+        offset = (offset_raw_value + 1) / 10 if add_offset else 0.0
+        return base_temp + offset
+
+    def _room_temp_logic(self, payload):
+        return self._room_or_ext_temp_logic(payload, 5)
+
+    def _ext_temp_logic(self, payload):
+        return self._room_or_ext_temp_logic(payload, 18)
+
     def get_temp(self) -> float:
         """Return the room temperature in degrees celsius."""
         payload = self.send_request([0x01, 0x03, 0x00, 0x00, 0x00, 0x08])
-        return payload[0x05] / 2.0
+        return self._room_temp_logic(payload)
 
     def get_external_temp(self) -> float:
         """Return the external temperature in degrees celsius."""
         payload = self.send_request([0x01, 0x03, 0x00, 0x00, 0x00, 0x08])
-        return payload[18] / 2.0
+        return self._ext_temp_logic(payload)
 
     def get_full_status(self) -> dict:
         """Return the state of the device.
@@ -64,7 +77,7 @@ class hysen(Device):
         data["power"] = payload[4] & 1
         data["active"] = (payload[4] >> 4) & 1
         data["temp_manual"] = (payload[4] >> 6) & 1
-        data["room_temp"] = payload[5] / 2.0
+        data["room_temp"] = self._room_temp_logic(payload)
         data["thermostat_temp"] = payload[6] / 2.0
         data["auto_mode"] = payload[7] & 0xF
         data["loop_mode"] = payload[7] >> 4
@@ -79,7 +92,7 @@ class hysen(Device):
         data["fre"] = payload[15]
         data["poweron"] = payload[16]
         data["unknown"] = payload[17]
-        data["external_temp"] = payload[18] / 2.0
+        data["external_temp"] = self._ext_temp_logic(payload)
         data["hour"] = payload[19]
         data["min"] = payload[20]
         data["sec"] = payload[21]


### PR DESCRIPTION
## Context
The Broadlink Hysen thermostats do support 1 decimal precision, but this library did not extract that information. This PR provides access to the additional bit of information.

## Proposed change

I decompiled a relevant Android app to learn how it extracts temperature values with 1 decimal place precision. The relevant part of the code can be found here: https://pastebin.com/EYHBJ5sn
I ported the logic to this codebase and the numbers are now showing up fine in HA.

I tested this with Computherm E400RF and Computherm E280 (a product by a Hungarian vendor). 

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New device
- [ ] New product id (the device is already supported with a different id)
- [x] New feature (which adds functionality to an existing device)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Checklist

- [x] The code change is tested and works locally.
- [x] The code has been formatted using Black.
- [x] The code follows the [Zen of Python](https://www.python.org/dev/peps/pep-0020/).
- [x] I am creating the Pull Request against the correct branch.
- [] Documentation added/updated.
