### PR TITLE
Rename MP1S state parameters

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -160,7 +160,7 @@ SUPPORTED_TYPES = {
         0x60C8: ("LB1", "Broadlink"),
         0x6112: ("LB1", "Broadlink"),
         0x644B: ("LB1", "Broadlink"),
-        0x644C: ("LB27 R1", "Broadlink"),        
+        0x644C: ("LB27 R1", "Broadlink"),
         0x644E: ("LB26 R1", "Broadlink"),
     },
     lb2: {
@@ -170,9 +170,9 @@ SUPPORTED_TYPES = {
     S1C: {
         0x2722: ("S2KIT", "Broadlink"),
     },
-    s3:  {
-        0xA59C:("S3", "Broadlink"),
-        0xA64D:("S3", "Broadlink"),
+    s3: {
+        0xA59C: ("S3", "Broadlink"),
+        0xA64D: ("S3", "Broadlink"),
     },
     hysen: {
         0x4EAD: ("HY02/HY03", "Hysen"),

--- a/broadlink/switch.py
+++ b/broadlink/switch.py
@@ -367,7 +367,7 @@ class mp1s(mp1):
 
     TYPE = "MP1S"
 
-    def get_status(self) -> dict:
+    def get_state(self) -> dict:
         """Return the power state of the device.
 
         voltage in V.

--- a/broadlink/switch.py
+++ b/broadlink/switch.py
@@ -368,8 +368,8 @@ class mp1s(mp1):
     TYPE = "MP1S"
 
     def get_status(self) -> dict:
-        """
-        Return the power state of the device.
+        """Return the power state of the device.
+
         voltage in V.
         current in A.
         power in W.
@@ -392,15 +392,15 @@ class mp1s(mp1):
         payload_str = payload.hex()[4:-6]
 
         def get_value(start, end, factors):
-            value = sum(int(payload_str[i-2:i]) * factor for i, 
-                        factor in zip(range(start, end, -2), factors))
+            value = sum(
+                int(payload_str[i - 2 : i]) * factor
+                for i, factor in zip(range(start, end, -2), factors)
+            )
             return value
-        
-        return {
-            'voltage': get_value(34, 30, [10, 0.1]),
-            'current': get_value(40, 34, [1, 0.01, 0.0001]),
-            'power': get_value(46, 40, [100, 1, 0.01]),
-            'power_consumption': get_value(54, 46, [10000, 100, 1, 0.01])
-        }
 
-        
+        return {
+            "volt": get_value(34, 30, [10, 0.1]),
+            "current": get_value(40, 34, [1, 0.01, 0.0001]),
+            "power": get_value(46, 40, [100, 1, 0.01]),
+            "totalconsum": get_value(54, 46, [10000, 100, 1, 0.01]),
+        }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please fill the template to help maintainers processing your PR.

  Don't forget to create the PR against the correct branch:
  - new product id -> new_product_ids
  - anything else -> dev
-->
## Proposed change
<!--
  Describe the change. How are you fixing the issue?
-->
Rename the newly added state parameters for MP1s to align with the state parameters used in the SP4 family.

For instance, in an SP4 payload, the parameters are as follows: {'pwr': 0, 'ntlight': 1, 'indicator': 1, 'usbpwr': 0, 'maxworktime': 0, 'usbmaxworktime': 0, 'ntlbrightness': 59, 'current': 0, 'volt': -1, 'power': 0, 'totalconsum': -1, 'overload': -1}.

So we are basically renaming "voltage" to "volt" and "power_consumption" to "totalconsum" in mp1s.get_state() to make it easier to integrate. The function name is also being changed from get_status to get_state.

## Type of change
<!--
  What type of change does your PR introduce?
  Please, check only 1 box!
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New device
- [ ] New product id (the device is already supported with a different id)
- [ ] New feature (which adds functionality to an existing device)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information
<!--
  Link docs and related issues, when applicable.
-->

- This PR fixes issue: fixes #
- This PR is related to: 
- Link to documentation pull request: 

## Checklist
<!--
  Please do your best to check these boxes.
-->

- [ ] The code change is tested and works locally.
- [ ] The code has been formatted using Black.
- [ ] The code follows the [Zen of Python](https://www.python.org/dev/peps/pep-0020/).
- [ ] I am creating the Pull Request against the correct branch.
- [ ] Documentation added/updated.
