### PR TITLE
Added support for another type of LB26 R1 smart light bulb

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -178,6 +178,7 @@ SUPPORTED_TYPES = {
         0xA4F4: ("LB27 R1", "Broadlink"),
         0xA5F7: ("LB27 R1", "Broadlink"),
         0xA6EF: ("EFCF60WSMT", "Luceco"),
+        0xA517: ("LB26 R1", "Broadlink"),
     },
     S1C: {
         0x2722: ("S2KIT", "Broadlink"),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please fill the template to help maintainers processing your PR.

  Don't forget to create the PR against the correct branch:
  - new product id -> new_product_ids
  - anything else -> dev
-->
## Context
<!--
--> Bought new LB26 R1 light bulbs that are not supported by this library due to their device type / product id


## Proposed change
<!--
--> Added a new device type / product id for Broadlink's LB26 R1 smart light bulb to __init__.py:
line 181: 0xA517: ("LB26 R1", "Broadlink"),


## Type of change
<!--
  What type of change does your PR introduce?
  Please, check only 1 box!
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New device
- [x] New product id (the device is already supported with a different id)
- [ ] New feature (which adds functionality to an existing device)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information
<!--
  Link docs and related issues, when applicable.
-->

- This PR fixes issue: fixes #
- This PR is related to: 
- Link to documentation pull request: 

## Checklist
<!--
  Please do your best to check these boxes.
-->

- [x] The code change is tested and works locally.
- [x] The code has been formatted using Black. (only a small section of a dictionary was changed)
- [x] The code follows the [Zen of Python](https://www.python.org/dev/peps/pep-0020/).  (only a small section of a dictionary was changed)
- [x] I am creating the Pull Request against the correct branch.
- [x] Documentation added/updated.  (only a small section of a dictionary was changed to add a new product id)
