### PR TITLE
Add RM5 plus device to Broadlink device list

### DIFF
--- a/broadlink/__init__.py
+++ b/broadlink/__init__.py
@@ -146,6 +146,7 @@ SUPPORTED_TYPES = {
         0x61A2: ("RM4 pro", "Broadlink"),
         0x649B: ("RM4 pro", "Broadlink"),
         0x653C: ("RM4 pro", "Broadlink"),
+        0x5224: ("RM5 plus", "Broadlink"),
     },
     a1: {
         0x2714: ("A1", "Broadlink"),


### PR DESCRIPTION
## Context
Broadlink Integration is failing to detect **RM5 plus** device with a new product ID. This change adds support for the new model ID to ensure proper device detection and functionality within Home Assistant.
**This PR addresses the issue of the missing product ID $0x5224$.**

## Proposed change
Add **RM5 plus** device with product ID **$0x5224$** to the `broadlink/__init__.py` device list. This allows the `mjg59/python-broadlink` library to correctly identify and initialize the device.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New device
- [x] **New product id (the device is already supported with a different id)**
- [ ] New feature (which adds functionality to an existing device)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information
- This PR fixes issue: fixes #149679
- This PR is related to: 
- Link to documentation pull request: 

## Checklist
- [x] The code change is tested and works locally.
- [ ] The code has been formatted using Black.
- [ ] The code follows the [Zen of Python](https://www.python.org/dev/peps/pep-0020/).
- [x] **I am creating the Pull Request against the correct branch.** (Assuming you checked the branch is `new_product_ids` as required for new product IDs)
- [ ] Documentation added/updated.